### PR TITLE
Use HeterogenousBag to handle lists of peripherals

### DIFF
--- a/src/main/scala/devices/pwm/PWM.scala
+++ b/src/main/scala/devices/pwm/PWM.scala
@@ -44,16 +44,6 @@ case class PWMConfig(
   regBytes: Int = 4,
   ncmp: Int = 4,
   cmpWidth: Int = 16)
-{
-  val bc = new PWMBundleConfig(ncmp)
-}
-
-case class PWMBundleConfig(
-  ncmp: Int)
-{
-  def union(that: PWMBundleConfig): PWMBundleConfig =
-    PWMBundleConfig(scala.math.max(ncmp, that.ncmp))
-}
 
 trait HasPWMParameters {
   implicit val p: Parameters

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -6,19 +6,20 @@ import config._
 import diplomacy.LazyModule
 import rocketchip.{TopNetwork,TopNetworkModule}
 import uncore.tilelink2.TLFragmenter
+import util.HeterogeneousBag
 
 import sifive.blocks.devices.gpio._
 
-class PWMPortIO(c: PWMBundleConfig)(implicit p: Parameters) extends Bundle {
+class PWMPortIO(c: PWMConfig)(implicit p: Parameters) extends Bundle {
   val port = Vec(c.ncmp, Bool()).asOutput
   override def cloneType: this.type = new PWMPortIO(c).asInstanceOf[this.type]
 }
 
-class PWMPinsIO(c: PWMBundleConfig)(implicit p: Parameters) extends Bundle {
+class PWMPinsIO(c: PWMConfig)(implicit p: Parameters) extends Bundle {
   val pwm = Vec(c.ncmp, new GPIOPin)
 }
 
-class PWMGPIOPort(c: PWMBundleConfig)(implicit p: Parameters) extends Module {
+class PWMGPIOPort(c: PWMConfig)(implicit p: Parameters) extends Module {
   val io = new Bundle {
     val pwm = new PWMPortIO(c).flip()
     val pins = new PWMPinsIO(c)
@@ -43,8 +44,7 @@ trait PeripheryPWMBundle {
     val p: Parameters
     val pwmConfigs: Seq[PWMConfig]
   } =>
-  val pwm_bc = pwmConfigs.map(_.bc).reduce(_.union(_))
-  val pwms = Vec(pwmConfigs.size, new PWMPortIO(pwm_bc)(p))
+  val pwms = HeterogeneousBag(pwmConfigs.map(new PWMPortIO(_)(p)))
 }
 
 trait PeripheryPWMModule {

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -5,6 +5,7 @@ import Chisel._
 import diplomacy.LazyModule
 import uncore.tilelink2._
 import rocketchip.{TopNetwork,TopNetworkModule}
+import util.HeterogeneousBag
 
 trait PeripherySPI {
   this: TopNetwork { val spiConfigs: Seq[SPIConfig] } =>
@@ -18,8 +19,7 @@ trait PeripherySPI {
 
 trait PeripherySPIBundle {
   this: { val spiConfigs: Seq[SPIConfig] } =>
-  val spi_bc = spiConfigs.map(_.bc).reduce(_.union(_))
-  val spis = Vec(spiConfigs.size, new SPIPortIO(spi_bc.toSPIConfig))
+  val spis = HeterogeneousBag(spiConfigs.map(new SPIPortIO(_)))
 }
 
 trait PeripherySPIModule {

--- a/src/main/scala/devices/spi/TLSPI.scala
+++ b/src/main/scala/devices/spi/TLSPI.scala
@@ -30,7 +30,6 @@ trait SPIConfigBase {
   lazy val txDepthBits = log2Floor(txDepth) + 1
   lazy val rxDepthBits = log2Floor(rxDepth) + 1
 
-  lazy val bc = new SPIBundleConfig(csWidth)
 }
 
 case class SPIConfig(
@@ -48,15 +47,6 @@ case class SPIConfig(
   require(frameBits >= 4)
   require(sampleDelay >= 0)
 }
-
-case class SPIBundleConfig(csWidth: Int)
-  {
-    def union(that: SPIBundleConfig): SPIBundleConfig =
-      SPIBundleConfig(scala.math.max(csWidth, that.csWidth))
-
-    def toSPIConfig: SPIConfig = new SPIConfig(rAddress = -1,
-      csWidth = csWidth)
-  }
 
 class SPITopBundle(val i: Vec[Vec[Bool]], val r: Vec[TLBundle]) extends Bundle
 


### PR DESCRIPTION
Previously we had to do weird things to make non-homogenous
lists of items (e.g. PWM Peripherals where ncmp were different from one to
the other) into a vector. But now Chisel supports a Record type,
and we use the HeterogeneousBag utility to do this more naturally.
This also deletes all the cruft which was introduced to get
around the limitation which doesn't exist anymore.