### PR TITLE
MockAON: Accept the non-debug interrupt as an input to overall reset.

### DIFF
--- a/src/main/scala/devices/mockaon/MockAONPeriphery.scala
+++ b/src/main/scala/devices/mockaon/MockAONPeriphery.scala
@@ -44,4 +44,5 @@ trait HasPeripheryMockAONModule extends HasTopLevelNetworksModule {
 
   outer.coreplex.module.io.rtcToggle := outer.aon.module.io.rtc.asUInt.toBool
 
+  outer.aon.module.io.ndreset := outer.coreplex.module.io.ndreset
 }

--- a/src/main/scala/devices/mockaon/MockAONWrapper.scala
+++ b/src/main/scala/devices/mockaon/MockAONWrapper.scala
@@ -56,6 +56,7 @@ class MockAONWrapper(w: Int, c: MockAONParams)(implicit p: Parameters) extends L
       val in = node.bundleIn
       val ip = intnode.bundleOut
       val rtc  = Clock(OUTPUT)
+      val ndreset = Bool(INPUT)
     }
 
     val aon_io = aon.module.io
@@ -99,7 +100,7 @@ class MockAONWrapper(w: Int, c: MockAONParams)(implicit p: Parameters) extends L
     val lfclk = aon_io.lfclk
 
     val aonrst_catch = Module (new ResetCatchAndSync(3))
-    aonrst_catch.reset := erst | aon_io.wdog_rst
+    aonrst_catch.reset := erst | aon_io.wdog_rst | io.ndreset
     aonrst_catch.clock := lfclk
     aon.module.reset := aonrst_catch.io.sync_reset
 


### PR DESCRIPTION
This allows the Debug Module to perform a system reset.

TODO: Need to add isolation as well, but need to think about any combinational loops potentially introduced