### PR TITLE
SPI errata fixes

### DIFF
--- a/src/main/scala/devices/spi/SPIFIFO.scala
+++ b/src/main/scala/devices/spi/SPIFIFO.scala
@@ -41,7 +41,7 @@ class SPIFIFO(c: SPIParamsBase) extends Module {
 
   val proto = SPIProtocol.decode(io.link.fmt.proto).zipWithIndex
   val cnt_quot = Mux1H(proto.map { case (s, i) => s -> (io.ctrl.fmt.len >> i) })
-  val cnt_rmdr = Mux1H(proto.map { case (s, i) => s -> (io.ctrl.fmt.len(i, 0).orR) })
+  val cnt_rmdr = Mux1H(proto.map { case (s, i) => s -> (if (i > 0) io.ctrl.fmt.len(i-1, 0).orR else UInt(0)) })
   io.link.fmt <> io.ctrl.fmt
   io.link.cnt := cnt_quot + cnt_rmdr
 

--- a/src/main/scala/devices/spi/SPIPhysical.scala
+++ b/src/main/scala/devices/spi/SPIPhysical.scala
@@ -82,7 +82,7 @@ class SPIPhysical(c: SPIParamsBase) extends Module {
   }
 
   val tx = (ctrl.fmt.iodir === SPIDirection.Tx)
-  val txen_in = (proto.head +: proto.tail.map(_ && tx)).scanRight(Bool(false))(_ || _)
+  val txen_in = (proto.head +: proto.tail.map(_ && tx)).scanRight(Bool(false))(_ || _).init
   val txen = txen_in :+ txen_in.last
 
   io.port.sck := sck


### PR DESCRIPTION
This fixes the following issues in the SPI master peripheral.

---

* **Issue**: The output enable signal for DQ[3] is not driven properly.
* **Symptoms**: Output data from master to slave is not properly transmitted in quad mode.  Data received from the slave is unaffected.
* **Workaround**: When interfacing with SPI flash devices, do not use the "Quad Input/Output Fast Read" command (opcode `0xEB`) while in the Extended SPI protocol.  Do not use the Native Quad SPI protocol.

---

* **Issue**: Configuring the frame length to certain values causes incorrect operation.
* **Symptoms**: Certain frame lengths result in the master sending one extra clock pulse.  The slave device may then become desynchronized.
* **Workaround**: The following frame lengths are supported and can be used. Do not use other frame lengths.

| Mode | Lengths |
| --- | --- |
| Serial | 0, 2, 4, 6, 8 |
| Dual | 0, 1, 3, 5, 7, 8 |
| Quad | 0, 1, 2, 3, 5, 6, 7, 8 |