### PR TITLE
Make more peripherals "listable" to allow for 0 or more

### DIFF
--- a/src/main/scala/devices/gpio/GPIOPeriphery.scala
+++ b/src/main/scala/devices/gpio/GPIOPeriphery.scala
@@ -11,22 +11,27 @@ import rocketchip.{
 }
 import uncore.tilelink2.TLFragmenter
 
-case object PeripheryGPIOKey extends Field[GPIOParams]
+case object PeripheryGPIOKey extends Field[Seq[GPIOParams]]
 
 trait HasPeripheryGPIO extends HasTopLevelNetworks {
   val gpioParams = p(PeripheryGPIOKey)
-  val gpio = LazyModule(new TLGPIO(peripheryBusBytes, gpioParams))
-  gpio.node := TLFragmenter(peripheryBusBytes, cacheBlockBytes)(peripheryBus.node)
-  intBus.intnode := gpio.intnode
+  val gpio = gpioParams map {params =>
+    val gpio = LazyModule(new TLGPIO(peripheryBusBytes, params))
+    gpio.node := TLFragmenter(peripheryBusBytes, cacheBlockBytes)(peripheryBus.node)
+    intBus.intnode := gpio.intnode
+    gpio
+  }
 }
 
 trait HasPeripheryGPIOBundle extends HasTopLevelNetworksBundle {
   val outer: HasPeripheryGPIO
-  val gpio = new GPIOPortIO(outer.gpioParams)
+  val gpio = HeterogeneousBag(outer.gpioParams(map(new GPIOPortIO(_))))
 }
 
 trait HasPeripheryGPIOModule extends HasTopLevelNetworksModule {
   val outer: HasPeripheryGPIO
   val io: HasPeripheryGPIOBundle
-  io.gpio <> outer.gpio.module.io.port
+  (io.gpio zip outer.gpio) foreach { case (io, device) =>
+    io.gpio <> device.module.io.port
+  }
 }

--- a/src/main/scala/devices/gpio/GPIOPeriphery.scala
+++ b/src/main/scala/devices/gpio/GPIOPeriphery.scala
@@ -10,6 +10,7 @@ import rocketchip.{
   HasTopLevelNetworksModule
 }
 import uncore.tilelink2.TLFragmenter
+import util.HeterogeneousBag
 
 case object PeripheryGPIOKey extends Field[Seq[GPIOParams]]
 
@@ -25,13 +26,13 @@ trait HasPeripheryGPIO extends HasTopLevelNetworks {
 
 trait HasPeripheryGPIOBundle extends HasTopLevelNetworksBundle {
   val outer: HasPeripheryGPIO
-  val gpio = HeterogeneousBag(outer.gpioParams(map(new GPIOPortIO(_))))
+  val gpio = HeterogeneousBag(outer.gpioParams.map(new GPIOPortIO(_)))
 }
 
 trait HasPeripheryGPIOModule extends HasTopLevelNetworksModule {
   val outer: HasPeripheryGPIO
   val io: HasPeripheryGPIOBundle
   (io.gpio zip outer.gpio) foreach { case (io, device) =>
-    io.gpio <> device.module.io.port
+    io <> device.module.io.port
   }
 }

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -52,7 +52,7 @@ trait HasPeripherySPIFlash extends HasTopLevelNetworks {
 
 trait HasPeripherySPIFlashBundle extends HasTopLevelNetworksBundle {
   val outer: HasPeripherySPIFlash 
-  val qspi = HeterogenousBag(outer.spiFlashParams.map(new SPIPortIO(_)))
+  val qspi = HeterogeneousBag(outer.spiFlashParams.map(new SPIPortIO(_)))
 }
 
 trait HasPeripherySPIFlashModule extends HasTopLevelNetworksModule {
@@ -60,7 +60,7 @@ trait HasPeripherySPIFlashModule extends HasTopLevelNetworksModule {
   val io: HasPeripherySPIFlashBundle
 
   (io.qspi zip outer.qspi) foreach { case (io, device) => 
-    io.qspi <> device.module.io.port
+    io <> device.module.io.port
   }
 }
 


### PR DESCRIPTION
Some peripherals take a list of parameters, to allow for 0 or more. GPIO and SPIFlash were exceptions. I don't see a really great reason for this constraint. Alternatively, they could be Options. Thoughts?