### PR TITLE
periphery: convert bundle traits 

### DIFF
--- a/src/main/scala/devices/gpio/GPIOPeriphery.scala
+++ b/src/main/scala/devices/gpio/GPIOPeriphery.scala
@@ -3,18 +3,14 @@ package sifive.blocks.devices.gpio
 
 import Chisel._
 import config.Field
-import diplomacy.LazyModule
-import rocketchip.{
-  HasTopLevelNetworks,
-  HasTopLevelNetworksBundle,
-  HasTopLevelNetworksModule
-}
+import diplomacy.{LazyModule,LazyMultiIOModuleImp}
+import rocketchip.HasSystemNetworks
 import uncore.tilelink2.TLFragmenter
 import util.HeterogeneousBag
 
 case object PeripheryGPIOKey extends Field[Seq[GPIOParams]]
 
-trait HasPeripheryGPIO extends HasTopLevelNetworks {
+trait HasPeripheryGPIO extends HasSystemNetworks {
   val gpioParams = p(PeripheryGPIOKey)
   val gpio = gpioParams map {params =>
     val gpio = LazyModule(new TLGPIO(peripheryBusBytes, params))
@@ -24,15 +20,15 @@ trait HasPeripheryGPIO extends HasTopLevelNetworks {
   }
 }
 
-trait HasPeripheryGPIOBundle extends HasTopLevelNetworksBundle {
-  val outer: HasPeripheryGPIO
-  val gpio = HeterogeneousBag(outer.gpioParams.map(new GPIOPortIO(_)))
+trait HasPeripheryGPIOBundle {
+  val gpio: HeterogeneousBag[GPIOPortIO]
 }
 
-trait HasPeripheryGPIOModule extends HasTopLevelNetworksModule {
+trait HasPeripheryGPIOModuleImp extends LazyMultiIOModuleImp with HasPeripheryGPIOBundle {
   val outer: HasPeripheryGPIO
-  val io: HasPeripheryGPIOBundle
-  (io.gpio zip outer.gpio) foreach { case (io, device) =>
+  val gpio = IO(HeterogeneousBag(outer.gpioParams.map(new GPIOPortIO(_))))
+
+  (gpio zip outer.gpio) foreach { case (io, device) =>
     io <> device.module.io.port
   }
 }

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -3,13 +3,13 @@ package sifive.blocks.devices.i2c
 
 import Chisel._
 import config.Field
-import diplomacy.LazyModule
-import rocketchip.{HasTopLevelNetworks,HasTopLevelNetworksBundle,HasTopLevelNetworksModule}
+import diplomacy.{LazyModule,LazyMultiIOModuleImp}
+import rocketchip.{HasSystemNetworks}
 import uncore.tilelink2.TLFragmenter
 
 case object PeripheryI2CKey extends Field[Seq[I2CParams]]
 
-trait HasPeripheryI2C extends HasTopLevelNetworks {
+trait HasPeripheryI2C extends HasSystemNetworks {
   val i2cParams = p(PeripheryI2CKey)
   val i2c = i2cParams map { params =>
     val i2c = LazyModule(new TLI2C(peripheryBusBytes, params))
@@ -19,15 +19,21 @@ trait HasPeripheryI2C extends HasTopLevelNetworks {
   }
 }
 
-trait HasPeripheryI2CBundle extends HasTopLevelNetworksBundle{
-  val outer: HasPeripheryI2C
-  val i2cs = Vec(outer.i2cParams.size, new I2CPort)
+trait HasPeripheryI2CBundle {
+  val i2cs: Vec[I2CPort]
+
+  def toGPIOPins(dummy: Int = 1): Seq[I2CGPIOPort] = i2cs.map { i =>
+    val pin = Module(new I2CGPIOPort)
+    pin.io.i2c <> i
+    pin
+  }
 }
 
-trait HasPeripheryI2CModule extends HasTopLevelNetworksModule {
+trait HasPeripheryI2CModuleImp extends LazyMultiIOModuleImp with HasPeripheryI2CBundle {
   val outer: HasPeripheryI2C
-  val io: HasPeripheryI2CBundle
-  (io.i2cs zip outer.i2c).foreach { case (io, device) =>
+  val i2cs = IO(Vec(outer.i2cParams.size, new I2CPort))
+
+  (i2cs zip outer.i2c).foreach { case (io, device) =>
     io <> device.module.io.port
   }
 }

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -22,10 +22,10 @@ trait HasPeripheryI2C extends HasSystemNetworks {
 trait HasPeripheryI2CBundle {
   val i2cs: Vec[I2CPort]
 
-  def toGPIOPins(syncStages: Int = 0): Seq[I2CGPIOPort] = i2cs.map { i =>
-    val pin = Module(new I2CGPIOPort(syncStages))
-    pin.io.i2c <> i
-    pin
+  def I2CtoGPIOPins(syncStages: Int = 0): Seq[I2CPinsIO] = i2cs.map { i =>
+    val pins = Module(new I2CGPIOPort(syncStages))
+    pins.io.i2c <> i
+    pins.io.pins
   }
 }
 

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -22,8 +22,8 @@ trait HasPeripheryI2C extends HasSystemNetworks {
 trait HasPeripheryI2CBundle {
   val i2cs: Vec[I2CPort]
 
-  def toGPIOPins(dummy: Int = 1): Seq[I2CGPIOPort] = i2cs.map { i =>
-    val pin = Module(new I2CGPIOPort)
+  def toGPIOPins(syncStages: Int = 0): Seq[I2CGPIOPort] = i2cs.map { i =>
+    val pin = Module(new I2CGPIOPort(syncStages))
     pin.io.i2c <> i
     pin
   }

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -43,10 +43,10 @@ trait HasPeripheryPWM extends HasSystemNetworks {
 trait HasPeripheryPWMBundle {
   val pwms: HeterogeneousBag[PWMPortIO]
 
-  def PWMtoGPIOPins(dummy: Int = 1): Seq[PWMGPIOPort] = pwms.map { p =>
-    val pin = Module(new PWMGPIOPort(p.c))
-    pin.io.pwm <> p
-    pin
+  def PWMtoGPIOPins(dummy: Int = 1): Seq[PWMPinsIO] = pwms.map { p =>
+    val pins = Module(new PWMGPIOPort(p.c))
+    pins.io.pwm <> p
+    pins.io.pins
   }
 }
 

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -3,27 +3,23 @@ package sifive.blocks.devices.pwm
 
 import Chisel._
 import config.Field
-import diplomacy.LazyModule
-import rocketchip.{
-  HasTopLevelNetworks,
-  HasTopLevelNetworksBundle,
-  HasTopLevelNetworksModule
-}
+import diplomacy.{LazyModule,LazyMultiIOModuleImp}
+import rocketchip.HasSystemNetworks
 import uncore.tilelink2.TLFragmenter
 import util.HeterogeneousBag
 
 import sifive.blocks.devices.gpio._
 
-class PWMPortIO(c: PWMParams) extends Bundle {
+class PWMPortIO(val c: PWMParams) extends Bundle {
   val port = Vec(c.ncmp, Bool()).asOutput
   override def cloneType: this.type = new PWMPortIO(c).asInstanceOf[this.type]
 }
 
-class PWMPinsIO(c: PWMParams) extends Bundle {
+class PWMPinsIO(val c: PWMParams) extends Bundle {
   val pwm = Vec(c.ncmp, new GPIOPin)
 }
 
-class PWMGPIOPort(c: PWMParams) extends Module {
+class PWMGPIOPort(val c: PWMParams) extends Module {
   val io = new Bundle {
     val pwm = new PWMPortIO(c).flip()
     val pins = new PWMPinsIO(c)
@@ -34,7 +30,7 @@ class PWMGPIOPort(c: PWMParams) extends Module {
 
 case object PeripheryPWMKey extends Field[Seq[PWMParams]]
 
-trait HasPeripheryPWM extends HasTopLevelNetworks {
+trait HasPeripheryPWM extends HasSystemNetworks {
   val pwmParams = p(PeripheryPWMKey)
   val pwms = pwmParams map { params =>
     val pwm = LazyModule(new TLPWM(peripheryBusBytes, params))
@@ -44,16 +40,21 @@ trait HasPeripheryPWM extends HasTopLevelNetworks {
   }
 }
 
-trait HasPeripheryPWMBundle extends HasTopLevelNetworksBundle {
-  val outer: HasPeripheryPWM
-  val pwms = HeterogeneousBag(outer.pwmParams.map(new PWMPortIO(_)))
+trait HasPeripheryPWMBundle {
+  val pwms: HeterogeneousBag[PWMPortIO]
+
+  def PWMtoGPIOPins(dummy: Int = 1): Seq[PWMGPIOPort] = pwms.map { p =>
+    val pin = Module(new PWMGPIOPort(p.c))
+    pin.io.pwm <> p
+    pin
+  }
 }
 
-trait HasPeripheryPWMModule extends HasTopLevelNetworksModule {
+trait HasPeripheryPWMModuleImp extends LazyMultiIOModuleImp with HasPeripheryPWMBundle {
   val outer: HasPeripheryPWM
-  val io: HasPeripheryPWMBundle
+  val pwms = IO(HeterogeneousBag(outer.pwmParams.map(new PWMPortIO(_))))
 
-  (io.pwms zip outer.pwms) foreach { case (io, device) =>
+  (pwms zip outer.pwms) foreach { case (io, device) =>
     io.port := device.module.io.gpio
   }
 }

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -23,10 +23,10 @@ trait HasPeripherySPI extends HasSystemNetworks {
 trait HasPeripherySPIBundle {
   val spis: HeterogeneousBag[SPIPortIO]
 
-  def SPItoGPIOPins(syncStages: Int = 0): Seq[SPIGPIOPort] = spis.map { s =>
-    val pin = Module(new SPIGPIOPort(s.c, syncStages))
-    pin.io.spi <> s
-    pin
+  def SPItoGPIOPins(syncStages: Int = 0): Seq[SPIPinsIO] = spis.map { s =>
+    val pins = Module(new SPIGPIOPort(s.c, syncStages))
+    pins.io.spi <> s
+    pins.io.pins
   }
 }
 
@@ -54,6 +54,15 @@ trait HasPeripherySPIFlash extends HasSystemNetworks {
 
 trait HasPeripherySPIFlashBundle {
   val qspi: HeterogeneousBag[SPIPortIO]
+
+  // It is important for SPIFlash that the syncStages is agreed upon, because
+  // internally it needs to realign the input data to the output SCK.
+  // Therefore, we rely on the syncStages parameter.
+  def SPIFlashtoGPIOPins(syncStages: Int = 0): Seq[SPIPinsIO] = qspi.map { s =>
+    val pins = Module(new SPIGPIOPort(s.c, syncStages))
+    pins.io.spi <> s
+    pins.io.pins
+  }
 }
 
 trait HasPeripherySPIFlashModuleImp extends LazyMultiIOModuleImp with HasPeripherySPIFlashBundle {

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -23,8 +23,8 @@ trait HasPeripherySPI extends HasSystemNetworks {
 trait HasPeripherySPIBundle {
   val spis: HeterogeneousBag[SPIPortIO]
 
-  def SPItoGPIOPins(sync_stages: Int = 0): Seq[SPIGPIOPort] = spis.map { s =>
-    val pin = Module(new SPIGPIOPort(s.c, sync_stages))
+  def SPItoGPIOPins(syncStages: Int = 0): Seq[SPIGPIOPort] = spis.map { s =>
+    val pin = Module(new SPIGPIOPort(s.c, syncStages))
     pin.io.spi <> s
     pin
   }

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -23,8 +23,8 @@ trait HasPeripherySPI extends HasSystemNetworks {
 trait HasPeripherySPIBundle {
   val spis: HeterogeneousBag[SPIPortIO]
 
-  def SPItoGPIOPins(dummy: Int = 1): Seq[SPIGPIOPort] = spis.map { s =>
-    val pin = Module(new SPIGPIOPort(s.c))
+  def SPItoGPIOPins(sync_stages: Int = 0): Seq[SPIGPIOPort] = spis.map { s =>
+    val pin = Module(new SPIGPIOPort(s.c, sync_stages))
     pin.io.spi <> s
     pin
   }

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -3,18 +3,14 @@ package sifive.blocks.devices.spi
 
 import Chisel._
 import config.Field
-import diplomacy.LazyModule
-import rocketchip.{
-  HasTopLevelNetworks,
-  HasTopLevelNetworksBundle,
-  HasTopLevelNetworksModule
-}
-import uncore.tilelink2.{TLFragmenter, TLWidthWidget}
+import diplomacy.{LazyModule,LazyMultiIOModuleImp}
+import rocketchip.HasSystemNetworks
+import uncore.tilelink2.{TLFragmenter,TLWidthWidget}
 import util.HeterogeneousBag
 
 case object PeripherySPIKey extends Field[Seq[SPIParams]]
 
-trait HasPeripherySPI extends HasTopLevelNetworks {
+trait HasPeripherySPI extends HasSystemNetworks {
   val spiParams = p(PeripherySPIKey)  
   val spis = spiParams map { params =>
     val spi = LazyModule(new TLSPI(peripheryBusBytes, params))
@@ -24,22 +20,28 @@ trait HasPeripherySPI extends HasTopLevelNetworks {
   }
 }
 
-trait HasPeripherySPIBundle extends HasTopLevelNetworksBundle {
-  val outer: HasPeripherySPI
-  val spis = HeterogeneousBag(outer.spiParams.map(new SPIPortIO(_)))
+trait HasPeripherySPIBundle {
+  val spis: HeterogeneousBag[SPIPortIO]
+
+  def SPItoGPIOPins(dummy: Int = 1): Seq[SPIGPIOPort] = spis.map { s =>
+    val pin = Module(new SPIGPIOPort(s.c))
+    pin.io.spi <> s
+    pin
+  }
 }
 
-trait HasPeripherySPIModule extends HasTopLevelNetworksModule {
+trait HasPeripherySPIModuleImp extends LazyMultiIOModuleImp with HasPeripherySPIBundle {
   val outer: HasPeripherySPI
-  val io: HasPeripherySPIBundle
-  (io.spis zip outer.spis).foreach { case (io, device) =>
+  val spis = IO(HeterogeneousBag(outer.spiParams.map(new SPIPortIO(_))))
+
+  (spis zip outer.spis).foreach { case (io, device) =>
     io <> device.module.io.port
   }
 }
 
 case object PeripherySPIFlashKey extends Field[Seq[SPIFlashParams]]
 
-trait HasPeripherySPIFlash extends HasTopLevelNetworks {
+trait HasPeripherySPIFlash extends HasSystemNetworks {
   val spiFlashParams = p(PeripherySPIFlashKey)  
   val qspi = spiFlashParams map { params =>
     val qspi = LazyModule(new TLSPIFlash(peripheryBusBytes, params))
@@ -50,16 +52,15 @@ trait HasPeripherySPIFlash extends HasTopLevelNetworks {
   }
 }
 
-trait HasPeripherySPIFlashBundle extends HasTopLevelNetworksBundle {
-  val outer: HasPeripherySPIFlash 
-  val qspi = HeterogeneousBag(outer.spiFlashParams.map(new SPIPortIO(_)))
+trait HasPeripherySPIFlashBundle {
+  val qspi: HeterogeneousBag[SPIPortIO]
 }
 
-trait HasPeripherySPIFlashModule extends HasTopLevelNetworksModule {
+trait HasPeripherySPIFlashModuleImp extends LazyMultiIOModuleImp with HasPeripherySPIFlashBundle {
   val outer: HasPeripherySPIFlash
-  val io: HasPeripherySPIFlashBundle
+  val qspi = IO(HeterogeneousBag(outer.spiFlashParams.map(new SPIPortIO(_))))
 
-  (io.qspi zip outer.qspi) foreach { case (io, device) => 
+  (qspi zip outer.qspi) foreach { case (io, device) => 
     io <> device.module.io.port
   }
 }

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -30,9 +30,9 @@ trait HasPeripheryUARTBundle {
   }
 
   def UARTtoGPIOPins(syncStages: Int = 0): Seq[UARTPinsIO] = uarts.map { u =>
-    val pin = Module(new UARTGPIOPort(syncStages))
-    pin.io.uart <> u
-    pin.io.pins
+    val pins = Module(new UARTGPIOPort(syncStages))
+    pins.io.uart <> u
+    pins.io.pins
   }
 }
 

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -3,20 +3,16 @@ package sifive.blocks.devices.uart
 
 import Chisel._
 import config.Field
-import diplomacy.LazyModule
-import rocketchip.{
-  HasTopLevelNetworks,
-  HasTopLevelNetworksBundle,
-  HasTopLevelNetworksModule
-}
-import uncore.tilelink2._
+import diplomacy.{LazyModule, LazyMultiIOModuleImp}
+import rocketchip.HasSystemNetworks
+import uncore.tilelink2.TLFragmenter
 
 import sifive.blocks.devices.gpio.{GPIOPin, GPIOOutputPinCtrl, GPIOInputPinCtrl}
 import sifive.blocks.util.ShiftRegisterInit
 
 case object PeripheryUARTKey extends Field[Seq[UARTParams]]
 
-trait HasPeripheryUART extends HasTopLevelNetworks {
+trait HasPeripheryUART extends HasSystemNetworks {
   val uartParams = p(PeripheryUARTKey)  
   val uarts = uartParams map { params =>
     val uart = LazyModule(new TLUART(peripheryBusBytes, params))
@@ -26,15 +22,25 @@ trait HasPeripheryUART extends HasTopLevelNetworks {
   }
 }
 
-trait HasPeripheryUARTBundle extends HasTopLevelNetworksBundle {
-  val outer: HasPeripheryUART
-  val uarts = Vec(outer.uartParams.size, new UARTPortIO)
+trait HasPeripheryUARTBundle {
+  val uarts: Vec[UARTPortIO]
+
+  def tieoffUARTs(dummy: Int = 1) {
+    uarts.foreach { _.rxd := UInt(1) }
+  }
+
+  def UARTtoGPIOPins(dummy: Int = 1): Seq[UARTGPIOPort] = uarts.map { u =>
+    val pin = Module(new UARTGPIOPort)
+    pin.io.uart <> u
+    pin
+  }
 }
 
-trait HasPeripheryUARTModule extends HasTopLevelNetworksModule {
+trait HasPeripheryUARTModuleImp extends LazyMultiIOModuleImp with HasPeripheryUARTBundle {
   val outer: HasPeripheryUART
-  val io: HasPeripheryUARTBundle
-  (io.uarts zip outer.uarts).foreach { case (io, device) =>
+  val uarts = IO(Vec(outer.uartParams.size, new UARTPortIO))
+
+  (uarts zip outer.uarts).foreach { case (io, device) =>
     io <> device.module.io.port
   }
 }

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -29,8 +29,8 @@ trait HasPeripheryUARTBundle {
     uarts.foreach { _.rxd := UInt(1) }
   }
 
-  def UARTtoGPIOPins(sync_stages: Int = 0): Seq[UARTGPIOPort] = uarts.map { u =>
-    val pin = Module(new UARTGPIOPort(sync_stages))
+  def UARTtoGPIOPins(syncStages: Int = 0): Seq[UARTGPIOPort] = uarts.map { u =>
+    val pin = Module(new UARTGPIOPort(syncStages))
     pin.io.uart <> u
     pin
   }

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -29,8 +29,8 @@ trait HasPeripheryUARTBundle {
     uarts.foreach { _.rxd := UInt(1) }
   }
 
-  def UARTtoGPIOPins(dummy: Int = 1): Seq[UARTGPIOPort] = uarts.map { u =>
-    val pin = Module(new UARTGPIOPort)
+  def UARTtoGPIOPins(sync_stages: Int = 0): Seq[UARTGPIOPort] = uarts.map { u =>
+    val pin = Module(new UARTGPIOPort(sync_stages))
     pin.io.uart <> u
     pin
   }

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -29,10 +29,10 @@ trait HasPeripheryUARTBundle {
     uarts.foreach { _.rxd := UInt(1) }
   }
 
-  def UARTtoGPIOPins(syncStages: Int = 0): Seq[UARTGPIOPort] = uarts.map { u =>
+  def UARTtoGPIOPins(syncStages: Int = 0): Seq[UARTPinsIO] = uarts.map { u =>
     val pin = Module(new UARTGPIOPort(syncStages))
     pin.io.uart <> u
-    pin
+    pin.io.pins
   }
 }
 

--- a/src/main/scala/devices/xilinxvc707mig/XilinxVC707MIGPeriphery.scala
+++ b/src/main/scala/devices/xilinxvc707mig/XilinxVC707MIGPeriphery.scala
@@ -2,29 +2,28 @@
 package sifive.blocks.devices.xilinxvc707mig
 
 import Chisel._
-import diplomacy._
-import rocketchip.{
-  HasTopLevelNetworks,
-  HasTopLevelNetworksModule,
-  HasTopLevelNetworksBundle
-}
-import coreplex.BankedL2Config
+import diplomacy.{LazyModule, LazyMultiIOModuleImp}
+import rocketchip.HasSystemNetworks
 
-trait HasPeripheryXilinxVC707MIG extends HasTopLevelNetworks {
-  val module: HasPeripheryXilinxVC707MIGModule
+trait HasPeripheryXilinxVC707MIG extends HasSystemNetworks {
+  val module: HasPeripheryXilinxVC707MIGModuleImp
 
   val xilinxvc707mig = LazyModule(new XilinxVC707MIG)
-  require(p(BankedL2Config).nMemoryChannels == 1, "Coreplex must have 1 master memory port")
+  require(nMemoryChannels == 1, "Coreplex must have 1 master memory port")
   xilinxvc707mig.node := mem(0).node
 }
 
-trait HasPeripheryXilinxVC707MIGBundle extends HasTopLevelNetworksBundle {
-  val xilinxvc707mig = new XilinxVC707MIGIO
+trait HasPeripheryXilinxVC707MIGBundle {
+  val xilinxvc707mig: XilinxVC707MIGIO
+  def connectXilinxVC707MIGToPads(pads: XilinxVC707MIGPads) {
+    pads <> xilinxvc707mig
+  }
 }
 
-trait HasPeripheryXilinxVC707MIGModule extends HasTopLevelNetworksModule {
+trait HasPeripheryXilinxVC707MIGModuleImp extends LazyMultiIOModuleImp
+    with HasPeripheryXilinxVC707MIGBundle {
   val outer: HasPeripheryXilinxVC707MIG
-  val io: HasPeripheryXilinxVC707MIGBundle
+  val xilinxvc707mig = IO(new XilinxVC707MIGIO)
 
-  io.xilinxvc707mig <> outer.xilinxvc707mig.module.io.port
+  xilinxvc707mig <> outer.xilinxvc707mig.module.io.port
 }

--- a/src/main/scala/devices/xilinxvc707pciex1/XilinxVC707PCIeX1Periphery.scala
+++ b/src/main/scala/devices/xilinxvc707pciex1/XilinxVC707PCIeX1Periphery.scala
@@ -2,16 +2,11 @@
 package sifive.blocks.devices.xilinxvc707pciex1
 
 import Chisel._
-import diplomacy.LazyModule
-import rocketchip.{
-  HasTopLevelNetworks,
-  HasTopLevelNetworksModule,
-  HasTopLevelNetworksBundle
-}
+import diplomacy.{LazyModule, LazyMultiIOModuleImp}
+import rocketchip.HasSystemNetworks
 import uncore.tilelink2._
 
-trait HasPeripheryXilinxVC707PCIeX1 extends HasTopLevelNetworks {
-
+trait HasPeripheryXilinxVC707PCIeX1 extends HasSystemNetworks {
   val xilinxvc707pcie = LazyModule(new XilinxVC707PCIeX1)
   private val intXing = LazyModule(new IntXing)
 
@@ -22,16 +17,20 @@ trait HasPeripheryXilinxVC707PCIeX1 extends HasTopLevelNetworks {
   intXing.intnode := xilinxvc707pcie.intnode
 }
 
-trait HasPeripheryXilinxVC707PCIeX1Bundle extends HasTopLevelNetworksBundle {
-  val xilinxvc707pcie = new XilinxVC707PCIeX1IO
+trait HasPeripheryXilinxVC707PCIeX1Bundle {
+  val xilinxvc707pcie: XilinxVC707PCIeX1IO
+  def connectXilinxVC707PCIeX1ToPads(pads: XilinxVC707PCIeX1Pads) {
+    pads <> xilinxvc707pcie
+  }
 }
 
-trait HasPeripheryXilinxVC707PCIeX1Module extends HasTopLevelNetworksModule {
+trait HasPeripheryXilinxVC707PCIeX1ModuleImp extends LazyMultiIOModuleImp
+    with HasPeripheryXilinxVC707PCIeX1Bundle {
   val outer: HasPeripheryXilinxVC707PCIeX1
-  val io: HasPeripheryXilinxVC707PCIeX1Bundle
+  val xilinxvc707pcie = IO(new XilinxVC707PCIeX1IO)
 
-  io.xilinxvc707pcie <> outer.xilinxvc707pcie.module.io.port
+  xilinxvc707pcie <> outer.xilinxvc707pcie.module.io.port
 
   outer.xilinxvc707pcie.module.clock := outer.xilinxvc707pcie.module.io.port.axi_aclk_out
-  outer.xilinxvc707pcie.module.reset := ~io.xilinxvc707pcie.axi_aresetn
+  outer.xilinxvc707pcie.module.reset := ~xilinxvc707pcie.axi_aresetn
 }


### PR DESCRIPTION
...to work with system-level multi-io module.

The abstract bundle traits can either be mixed into Bundles and made concrete with calls to `cloneType`, or mixed into ModuleImps and made concrete with `IO(...)`s. Examples of the latter use case are provided for each peripheral.

TODO in future PR: add more helper functions in the style of `toGPIOPins`