### PR TITLE
vc707 axi enhancements

### DIFF
--- a/src/main/scala/devices/xilinxvc707mig/XilinxVC707MIG.scala
+++ b/src/main/scala/devices/xilinxvc707mig/XilinxVC707MIG.scala
@@ -32,7 +32,7 @@ class XilinxVC707MIG(implicit p: Parameters) extends LazyModule with HasXilinxVC
     beatBytes = 8)))
 
   val xing    = LazyModule(new TLAsyncCrossing)
-  val toaxi4  = LazyModule(new TLToAXI4(beatBytes = 8))
+  val toaxi4  = LazyModule(new TLToAXI4(beatBytes = 8, adapterName = Some("mem"), stripBits = 1))
   val indexer = LazyModule(new AXI4IdIndexer(idBits = 4))
   val deint   = LazyModule(new AXI4Deinterleaver(p(coreplex.CacheBlockBytes)))
   val yank    = LazyModule(new AXI4UserYanker)

--- a/src/main/scala/devices/xilinxvc707pciex1/XilinxVC707PCIeX1.scala
+++ b/src/main/scala/devices/xilinxvc707pciex1/XilinxVC707PCIeX1.scala
@@ -38,7 +38,7 @@ class XilinxVC707PCIeX1(implicit p: Parameters) extends LazyModule {
 
   axi_to_pcie_x1.control :=
     AXI4Buffer()(
-    AXI4UserYanker()(
+    AXI4UserYanker(capMaxFlight = Some(2))(
     TLToAXI4(beatBytes=4)(
     TLFragmenter(4, p(coreplex.CacheBlockBytes))(
     TLAsyncCrossingSink()(

--- a/src/main/scala/devices/xilinxvc707pciex1/XilinxVC707PCIeX1.scala
+++ b/src/main/scala/devices/xilinxvc707pciex1/XilinxVC707PCIeX1.scala
@@ -32,7 +32,7 @@ class XilinxVC707PCIeX1(implicit p: Parameters) extends LazyModule {
     AXI4UserYanker()(
     AXI4Deinterleaver(p(coreplex.CacheBlockBytes))(
     AXI4IdIndexer(idBits=4)(
-    TLToAXI4(beatBytes=8)(
+    TLToAXI4(beatBytes=8, adapterName = Some("pcie-slave"))(
     TLAsyncCrossingSink()(
     slave))))))
 


### PR DESCRIPTION
1 - Print AXI-ID mappings
2 - Use half as many Deinterleaver buffers for the L2 backside
3 - Limit the Q depth on the PCIe control port to 2 (was 1584!)