### PR TITLE
periphery: peripherals now in coreplex

### DIFF
--- a/src/main/scala/devices/gpio/GPIOPeriphery.scala
+++ b/src/main/scala/devices/gpio/GPIOPeriphery.scala
@@ -3,19 +3,18 @@ package sifive.blocks.devices.gpio
 
 import Chisel._
 import freechips.rocketchip.config.Field
+import freechips.rocketchip.coreplex.{HasPeripheryBus, HasInterruptBus}
 import freechips.rocketchip.diplomacy.{LazyModule,LazyMultiIOModuleImp}
-import freechips.rocketchip.chip.HasSystemNetworks
-import freechips.rocketchip.tilelink.TLFragmenter
 import freechips.rocketchip.util.HeterogeneousBag
 
 case object PeripheryGPIOKey extends Field[Seq[GPIOParams]]
 
-trait HasPeripheryGPIO extends HasSystemNetworks {
+trait HasPeripheryGPIO extends HasPeripheryBus with HasInterruptBus {
   val gpioParams = p(PeripheryGPIOKey)
-  val gpio = gpioParams map {params =>
-    val gpio = LazyModule(new TLGPIO(peripheryBusBytes, params))
-    gpio.node := TLFragmenter(peripheryBusBytes, cacheBlockBytes)(peripheryBus.node)
-    intBus.intnode := gpio.intnode
+  val gpio = gpioParams map { params =>
+    val gpio = LazyModule(new TLGPIO(pbus.beatBytes, params))
+    gpio.node := pbus.toVariableWidthSlaves
+    ibus.fromSync := gpio.intnode
     gpio
   }
 }

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -3,18 +3,17 @@ package sifive.blocks.devices.i2c
 
 import Chisel._
 import freechips.rocketchip.config.Field
-import freechips.rocketchip.diplomacy.{LazyModule,LazyMultiIOModuleImp}
-import freechips.rocketchip.chip.{HasSystemNetworks}
-import freechips.rocketchip.tilelink.TLFragmenter
+import freechips.rocketchip.coreplex.{HasPeripheryBus, HasInterruptBus}
+import freechips.rocketchip.diplomacy.{LazyModule, LazyMultiIOModuleImp}
 
 case object PeripheryI2CKey extends Field[Seq[I2CParams]]
 
-trait HasPeripheryI2C extends HasSystemNetworks {
+trait HasPeripheryI2C extends HasPeripheryBus {
   val i2cParams = p(PeripheryI2CKey)
   val i2c = i2cParams map { params =>
-    val i2c = LazyModule(new TLI2C(peripheryBusBytes, params))
-    i2c.node := TLFragmenter(peripheryBusBytes, cacheBlockBytes)(peripheryBus.node)
-    intBus.intnode := i2c.intnode
+    val i2c = LazyModule(new TLI2C(pbus.beatBytes, params))
+    i2c.node := pbus.toVariableWidthSlaves
+    ibus.fromSync := i2c.intnode
     i2c
   }
 }

--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -2,8 +2,8 @@
 package sifive.blocks.devices.uart
 
 import Chisel._
-import freechips.rocketchip.chip.RTCPeriod
 import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.coreplex.RTCPeriod
 import freechips.rocketchip.diplomacy.DTSTimebase
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
@@ -205,7 +205,7 @@ trait HasUARTTopModuleContents extends Module with HasUARTParameters with HasReg
   val rxm = Module(new UARTRx(params))
   val rxq = Module(new Queue(rxm.io.out.bits, uartNRxEntries))
 
-  val divinit = p(DTSTimebase) * p(RTCPeriod) / 115200
+  val divinit = p(DTSTimebase) * BigInt(p(RTCPeriod).getOrElse(1)) / 115200
   val div = Reg(init = UInt(divinit, uartDivisorBits))
 
   private val stopCountBits = log2Up(uartStopBits)

--- a/src/main/scala/devices/xilinxvc707mig/XilinxVC707MIG.scala
+++ b/src/main/scala/devices/xilinxvc707mig/XilinxVC707MIG.scala
@@ -4,9 +4,8 @@ package sifive.blocks.devices.xilinxvc707mig
 import Chisel._
 import chisel3.experimental.{Analog,attach}
 import freechips.rocketchip.amba.axi4._
-import freechips.rocketchip.chip._
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.coreplex.CacheBlockBytes
+import freechips.rocketchip.coreplex._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import sifive.blocks.ip.xilinx.vc707mig.{VC707MIGIOClocksReset, VC707MIGIODDR, vc707mig}

--- a/src/main/scala/devices/xilinxvc707mig/XilinxVC707MIGPeriphery.scala
+++ b/src/main/scala/devices/xilinxvc707mig/XilinxVC707MIGPeriphery.scala
@@ -2,27 +2,28 @@
 package sifive.blocks.devices.xilinxvc707mig
 
 import Chisel._
+import freechips.rocketchip.coreplex.HasMemoryBus
 import freechips.rocketchip.diplomacy.{LazyModule, LazyMultiIOModuleImp}
-import freechips.rocketchip.chip.HasSystemNetworks
 
-trait HasPeripheryXilinxVC707MIG extends HasSystemNetworks {
-  val module: HasPeripheryXilinxVC707MIGModuleImp
+trait HasMemoryXilinxVC707MIG extends HasMemoryBus {
+  val module: HasMemoryXilinxVC707MIGModuleImp
 
   val xilinxvc707mig = LazyModule(new XilinxVC707MIG)
+
   require(nMemoryChannels == 1, "Coreplex must have 1 master memory port")
-  xilinxvc707mig.node := mem(0).node
+  xilinxvc707mig.node := memBuses.head.toDRAMController
 }
 
-trait HasPeripheryXilinxVC707MIGBundle {
+trait HasMemoryXilinxVC707MIGBundle {
   val xilinxvc707mig: XilinxVC707MIGIO
   def connectXilinxVC707MIGToPads(pads: XilinxVC707MIGPads) {
     pads <> xilinxvc707mig
   }
 }
 
-trait HasPeripheryXilinxVC707MIGModuleImp extends LazyMultiIOModuleImp
-    with HasPeripheryXilinxVC707MIGBundle {
-  val outer: HasPeripheryXilinxVC707MIG
+trait HasMemoryXilinxVC707MIGModuleImp extends LazyMultiIOModuleImp
+    with HasMemoryXilinxVC707MIGBundle {
+  val outer: HasMemoryXilinxVC707MIG
   val xilinxvc707mig = IO(new XilinxVC707MIGIO)
 
   xilinxvc707mig <> outer.xilinxvc707mig.module.io.port

--- a/src/main/scala/devices/xilinxvc707pciex1/XilinxVC707PCIeX1Periphery.scala
+++ b/src/main/scala/devices/xilinxvc707pciex1/XilinxVC707PCIeX1Periphery.scala
@@ -8,10 +8,10 @@ import freechips.rocketchip.diplomacy.{LazyModule, LazyMultiIOModuleImp}
 trait HasSystemXilinxVC707PCIeX1 extends HasSystemBus with HasInterruptBus {
   val xilinxvc707pcie = LazyModule(new XilinxVC707PCIeX1)
 
-  sbus.fromAsyncMasters() := xilinxvc707pcie.master
-  xilinxvc707pcie.slave   := sbus.toAsyncFixedWidthSlaves()
+  sbus.fromAsyncFIFOMaster() := xilinxvc707pcie.master
+  xilinxvc707pcie.slave := sbus.toAsyncFixedWidthSlaves()
   xilinxvc707pcie.control := sbus.toAsyncFixedWidthSlaves()
-  ibus.fromAsync          := xilinxvc707pcie.intnode
+  ibus.fromAsync := xilinxvc707pcie.intnode
 }
 
 trait HasSystemXilinxVC707PCIeX1Bundle {

--- a/src/main/scala/devices/xilinxvc707pciex1/XilinxVC707PCIeX1Periphery.scala
+++ b/src/main/scala/devices/xilinxvc707pciex1/XilinxVC707PCIeX1Periphery.scala
@@ -2,31 +2,28 @@
 package sifive.blocks.devices.xilinxvc707pciex1
 
 import Chisel._
+import freechips.rocketchip.coreplex.{HasInterruptBus, HasSystemBus}
 import freechips.rocketchip.diplomacy.{LazyModule, LazyMultiIOModuleImp}
-import freechips.rocketchip.chip.HasSystemNetworks
-import freechips.rocketchip.tilelink._
 
-trait HasPeripheryXilinxVC707PCIeX1 extends HasSystemNetworks {
+trait HasSystemXilinxVC707PCIeX1 extends HasSystemBus with HasInterruptBus {
   val xilinxvc707pcie = LazyModule(new XilinxVC707PCIeX1)
-  private val intXing = LazyModule(new IntXing)
 
-  fsb.node := TLAsyncCrossingSink()(xilinxvc707pcie.master)
-  xilinxvc707pcie.slave   := TLAsyncCrossingSource()(TLWidthWidget(socBusConfig.beatBytes)(socBus.node))
-  xilinxvc707pcie.control := TLAsyncCrossingSource()(TLWidthWidget(socBusConfig.beatBytes)(socBus.node))
-  intBus.intnode := intXing.intnode
-  intXing.intnode := xilinxvc707pcie.intnode
+  sbus.fromAsyncMasters() := xilinxvc707pcie.master
+  xilinxvc707pcie.slave   := sbus.toAsyncFixedWidthSlaves()
+  xilinxvc707pcie.control := sbus.toAsyncFixedWidthSlaves()
+  ibus.fromAsync          := xilinxvc707pcie.intnode
 }
 
-trait HasPeripheryXilinxVC707PCIeX1Bundle {
+trait HasSystemXilinxVC707PCIeX1Bundle {
   val xilinxvc707pcie: XilinxVC707PCIeX1IO
   def connectXilinxVC707PCIeX1ToPads(pads: XilinxVC707PCIeX1Pads) {
     pads <> xilinxvc707pcie
   }
 }
 
-trait HasPeripheryXilinxVC707PCIeX1ModuleImp extends LazyMultiIOModuleImp
-    with HasPeripheryXilinxVC707PCIeX1Bundle {
-  val outer: HasPeripheryXilinxVC707PCIeX1
+trait HasSystemXilinxVC707PCIeX1ModuleImp extends LazyMultiIOModuleImp
+    with HasSystemXilinxVC707PCIeX1Bundle {
+  val outer: HasSystemXilinxVC707PCIeX1
   val xilinxvc707pcie = IO(new XilinxVC707PCIeX1IO)
 
   xilinxvc707pcie <> outer.xilinxvc707pcie.module.io.port


### PR DESCRIPTION
Peripheral devices are now mixed-in to the `Coreplex` module where they attach to `pbus` and `ibus` using the attachment points provided by `TLBusWrapper`