### PR TITLE
Seperate GPIO Peripheral Functionality

### DIFF
--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -34,6 +34,14 @@ object IOFCtrl {
 // for the IOF
 class IOFPin extends Pin {
   val o  = new IOFCtrl().asOutput
+
+  def default(): Unit = {
+    this.o.oval  := Bool(false)
+    this.o.oe    := Bool(false)
+    this.o.ie    := Bool(false)
+    this.o.valid := Bool(false)
+  }
+
   def inputPin(pue: Bool = Bool(false) /*ignored*/): Bool = {
     this.o.oval := Bool(false)
     this.o.oe   := Bool(false)
@@ -53,7 +61,7 @@ class IOFPin extends Pin {
 
 // Connect both the i and o side of the pin,
 // and drive the valid signal for the IOF.
-object GPIOPinToIOF {
+object BasePinToIOF {
   def apply(pin: BasePin, iof: IOFPin): Unit = {
     iof <> pin
     iof.o.valid := Bool(true)

--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -2,6 +2,7 @@
 package sifive.blocks.devices.gpio
 
 import Chisel._
+import sifive.blocks.devices.pinctrl.{PinCtrl, Pin, BasePin, EnhancedPin, EnhancedPinCtrl}
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
@@ -9,28 +10,18 @@ import freechips.rocketchip.util.{AsyncResetRegVec, GenericParameterizedBundle}
 
 case class GPIOParams(address: BigInt, width: Int, includeIOF: Boolean = false)
 
-// YAGNI: Make the PUE, DS, and
-// these also optionally HW controllable.
-// This is the base class of things you "always"
-// want to control from a HW block.
-class GPIOCtrl extends Bundle {
-  val oval = Bool()
-  val oe   = Bool()
-  val ie   = Bool()
-}
-
-// This is the actual IOF interface.
+// This is the actual IOF interface.pa
 // Add a valid bit to indicate whether
 // there is something actually connected
 // to this.
-class GPIOPinIOFCtrl extends GPIOCtrl {
+class IOFCtrl extends PinCtrl {
   val valid = Bool()
 }
 
 // By default,
-object GPIOPinIOFCtrl {
-  def apply(): GPIOPinIOFCtrl = {
-    val iof = Wire(new GPIOPinIOFCtrl())
+object IOFCtrl {
+  def apply(): IOFCtrl = {
+    val iof = Wire(new IOFCtrl())
     iof.valid := Bool(false)
     iof.oval  := Bool(false)
     iof.oe    := Bool(false)
@@ -39,53 +30,34 @@ object GPIOPinIOFCtrl {
   }
 }
 
-// This is the control for a physical
-// Pad.
-
-class GPIOPinCtrl extends GPIOCtrl {
-  val pue  = Bool() // Pull-up Enable
-  val ds   = Bool() // Drive Strength
-}
-
-object GPIOPinCtrl {
-  def apply(): GPIOPinCtrl = {
-    val pin = Wire(new GPIOPinCtrl())
-    pin.oval := Bool(false)
-    pin.oe   := Bool(false)
-    pin.pue  := Bool(false)
-    pin.ds   := Bool(false)
-    pin.ie   := Bool(false)
-    pin
-  }
-}
-
 // Package up the inputs and outputs
 // for the IOF
-class GPIOPinIOF extends Bundle {
-  val i = new Bundle {
-    val ival = Bool(INPUT)
+class IOFPin extends Pin {
+  val o  = new IOFCtrl().asOutput
+  def inputPin(pue: Bool = Bool(false) /*ignored*/): Bool = {
+    this.o.oval := Bool(false)
+    this.o.oe   := Bool(false)
+    this.o.ie   := Bool(true)
+    this.i.ival
   }
-  val o = new GPIOPinIOFCtrl().asOutput
+  def outputPin(signal: Bool,
+    pue: Bool = Bool(false), /*ignored*/
+    ds: Bool = Bool(false), /*ignored*/
+    ie: Bool = Bool(false)
+  ): Unit = {
+    this.o.oval := signal
+    this.o.oe   := Bool(true)
+    this.o.ie   := ie
+  }
 }
 
 // Connect both the i and o side of the pin,
 // and drive the valid signal for the IOF.
 object GPIOPinToIOF {
-
-  def apply (pin: GPIOPin, iof: GPIOPinIOF): Unit = {
+  def apply(pin: BasePin, iof: IOFPin): Unit = {
     iof <> pin
     iof.o.valid := Bool(true)
   }
-
-}
-
-// Package up the inputs and outputs
-// for the Pin
-class GPIOPin extends Bundle {
-  val i = new Bundle {
-    val ival = Bool(INPUT)
-  }
-  val o = new GPIOPinCtrl().asOutput
 }
 
 // This is sort of weird because
@@ -94,9 +66,9 @@ class GPIOPin extends Bundle {
 // outside of RocketChipTop.
 
 class GPIOPortIO(c: GPIOParams) extends GenericParameterizedBundle(c) {
-  val pins = Vec(c.width, new GPIOPin)
-  val iof_0 = if (c.includeIOF) Some(Vec(c.width, new GPIOPinIOF).flip) else None
-  val iof_1 = if (c.includeIOF) Some(Vec(c.width, new GPIOPinIOF).flip) else None
+  val pins = Vec(c.width, new EnhancedPin())
+  val iof_0 = if (c.includeIOF) Some(Vec(c.width, new IOFPin).flip) else None
+  val iof_1 = if (c.includeIOF) Some(Vec(c.width, new IOFPin).flip) else None
 }
 
 // It would be better if the IOF were here and
@@ -183,15 +155,14 @@ trait HasGPIOModuleContents extends Module with HasRegMap {
   // Actual Pinmux
   // -------------------------------------------------
 
-  val swPinCtrl = Wire(Vec(c.width, new GPIOPinCtrl()))
+  val swPinCtrl = Wire(Vec(c.width, new EnhancedPinCtrl()))
 
   // This strips off the valid.
-  val iof0Ctrl = Wire(Vec(c.width, new GPIOCtrl()))
-  val iof1Ctrl = Wire(Vec(c.width, new GPIOCtrl()))
+  val iof0Ctrl = Wire(Vec(c.width, new EnhancedPinCtrl()))
+  val iof1Ctrl = Wire(Vec(c.width, new EnhancedPinCtrl()))
 
-  val iofCtrl = Wire(Vec(c.width, new GPIOCtrl()))
-  val iofPlusSwPinCtrl = Wire(Vec(c.width, new GPIOPinCtrl()))
-
+  val iofCtrl = Wire(Vec(c.width, new EnhancedPinCtrl()))
+  val iofPlusSwPinCtrl = Wire(Vec(c.width, new EnhancedPinCtrl()))
 
   for (pin <- 0 until c.width) {
 
@@ -202,7 +173,7 @@ trait HasGPIOModuleContents extends Module with HasRegMap {
     swPinCtrl(pin).ds     := dsReg(pin)
     swPinCtrl(pin).ie     := ieReg.io.q(pin)
 
-    val pre_xor = Wire(new GPIOPinCtrl())
+    val pre_xor = Wire(new EnhancedPinCtrl())
 
     if (c.includeIOF) {
       // Allow SW Override for invalid inputs.
@@ -244,57 +215,6 @@ trait HasGPIOModuleContents extends Module with HasRegMap {
       io.port.iof_1.get(pin).i.ival := inSyncReg(pin)
     }
   }
-}
-
-object GPIOOutputPinCtrl {
-
-  def apply( pin: GPIOPin, signal: Bool,
-    pue: Bool = Bool(false),
-    ds:  Bool = Bool(false),
-    ie:  Bool = Bool(false)
-  ): Unit = {
-    pin.o.oval := signal
-    pin.o.oe   := Bool(true)
-    pin.o.pue  := pue
-    pin.o.ds   := ds
-    pin.o.ie   := ie
-  }
-
-  def apply(pins: Vec[GPIOPin], signals: Bits,
-    pue: Bool, ds:  Bool, ie:  Bool
-  ): Unit = {
-    for ((signal, pin) <- (signals.toBools zip pins)) {
-      apply(pin, signal, pue, ds, ie)
-    }
-  }
-
-  def apply(pins: Vec[GPIOPin], signals: Bits): Unit = apply(pins, signals,
-    Bool(false), Bool(false), Bool(false))
-
-}
-
-object GPIOInputPinCtrl {
-
-  def apply (pin: GPIOPin, pue: Bool = Bool(false)): Bool = {
-    pin.o.oval := Bool(false)
-    pin.o.oe   := Bool(false)
-    pin.o.pue  := pue
-    pin.o.ds   := Bool(false)
-    pin.o.ie   := Bool(true)
-
-    pin.i.ival
-  }
-
-  def apply (pins: Vec[GPIOPin], pue: Bool): Vec[Bool] = {
-    val signals = Wire(Vec.fill(pins.size)(Bool(false)))
-    for ((signal, pin) <- (signals zip pins)) {
-      signal := GPIOInputPinCtrl(pin, pue)
-    }
-    signals
-  }
-
-  def apply (pins: Vec[GPIOPin]): Vec[Bool] = apply(pins, Bool(false))
-
 }
 
 // Magic TL2 Incantation to create a TL2 Slave

--- a/src/main/scala/devices/gpio/GPIOPeriphery.scala
+++ b/src/main/scala/devices/gpio/GPIOPeriphery.scala
@@ -12,7 +12,7 @@ case object PeripheryGPIOKey extends Field[Seq[GPIOParams]]
 
 trait HasPeripheryGPIO extends HasSystemNetworks {
   val gpioParams = p(PeripheryGPIOKey)
-  val gpio = gpioParams map {params =>
+  val gpios = gpioParams map {params =>
     val gpio = LazyModule(new TLGPIO(peripheryBusBytes, params))
     gpio.node := TLFragmenter(peripheryBusBytes, cacheBlockBytes)(peripheryBus.node)
     intBus.intnode := gpio.intnode
@@ -28,7 +28,7 @@ trait HasPeripheryGPIOModuleImp extends LazyMultiIOModuleImp with HasPeripheryGP
   val outer: HasPeripheryGPIO
   val gpio = IO(HeterogeneousBag(outer.gpioParams.map(new GPIOPortIO(_))))
 
-  (gpio zip outer.gpio) foreach { case (io, device) =>
+  (gpio zip outer.gpios) foreach { case (io, device) =>
     io <> device.module.io.port
   }
 }

--- a/src/main/scala/devices/gpio/GPIOPins.scala
+++ b/src/main/scala/devices/gpio/GPIOPins.scala
@@ -16,7 +16,7 @@ class GPIOPins[T <: Pin] (pingen: ()=> T,  c: GPIOParams) extends Bundle {
   override def cloneType: this.type =
     this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
 
-  def fromGPIOPort(port: GPIOPortIO){
+  def fromPort(port: GPIOPortIO){
 
     // This will just match up the components of the Bundle that
     // exist in both.

--- a/src/main/scala/devices/gpio/GPIOPins.scala
+++ b/src/main/scala/devices/gpio/GPIOPins.scala
@@ -1,0 +1,27 @@
+// See LICENSE for license details.
+package sifive.blocks.devices.gpio
+
+import Chisel._
+import sifive.blocks.devices.pinctrl.{Pin}
+
+// While this is a bit pendantic, it keeps the GPIO
+// device more similar to the other devices. It's not 'special'
+// even though it looks like something that more directly talks to
+// a pin. It also makes it possible to change the exact
+// type of pad this connects to.
+class GPIOPins[T <: Pin] (pingen: ()=> T,  c: GPIOParams) extends Bundle {
+
+  val pins = Vec(c.width, pingen())
+
+  override def cloneType: this.type =
+    this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
+
+  def fromGPIOPort(port: GPIOPortIO){
+
+    // This will just match up the components of the Bundle that
+    // exist in both.
+    (pins zip port.pins) foreach {case (pin, port) =>
+      pin <> port
+    }
+  }
+}

--- a/src/main/scala/devices/i2c/I2C.scala
+++ b/src/main/scala/devices/i2c/I2C.scala
@@ -46,7 +46,6 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util.{AsyncResetRegVec, Majority}
-import sifive.blocks.devices.gpio.{GPIOPinCtrl}
 
 case class I2CParams(address: BigInt)
 

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -21,12 +21,6 @@ trait HasPeripheryI2C extends HasSystemNetworks {
 
 trait HasPeripheryI2CBundle {
   val i2cs: Vec[I2CPort]
-
-  def I2CtoGPIOPins(syncStages: Int = 0): Seq[I2CPinsIO] = i2cs.map { i =>
-    val pins = Module(new I2CGPIOPort(syncStages))
-    pins.io.i2c <> i
-    pins.io.pins
-  }
 }
 
 trait HasPeripheryI2CModuleImp extends LazyMultiIOModuleImp with HasPeripheryI2CBundle {

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -25,9 +25,9 @@ trait HasPeripheryI2CBundle {
 
 trait HasPeripheryI2CModuleImp extends LazyMultiIOModuleImp with HasPeripheryI2CBundle {
   val outer: HasPeripheryI2C
-  val i2cs = IO(Vec(outer.i2cParams.size, new I2CPort))
+  val i2c = IO(Vec(outer.i2cParams.size, new I2CPort))
 
-  (i2cs zip outer.i2c).foreach { case (io, device) =>
+  (i2c zip outer.i2c).foreach { case (io, device) =>
     io <> device.module.io.port
   }
 }

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -20,7 +20,7 @@ trait HasPeripheryI2C extends HasSystemNetworks {
 }
 
 trait HasPeripheryI2CBundle {
-  val i2cs: Vec[I2CPort]
+  val i2c: Vec[I2CPort]
 }
 
 trait HasPeripheryI2CModuleImp extends LazyMultiIOModuleImp with HasPeripheryI2CBundle {

--- a/src/main/scala/devices/i2c/I2CPins.scala
+++ b/src/main/scala/devices/i2c/I2CPins.scala
@@ -12,6 +12,9 @@ class I2CPins[T <: Pin](pingen: () => T) extends Bundle {
   val scl: T = pingen()
   val sda: T = pingen()
 
+  override def cloneType: this.type =
+    this.getClass.getConstructors.head.newInstance(pingen).asInstanceOf[this.type]
+
   def fromI2CPort(i2c: I2CPort, clock: Clock, reset: Bool, syncStages: Int = 0) = {
     withClockAndReset(clock, reset) {
       scl.outputPin(i2c.scl.out, pue=true.B, ie = true.B)

--- a/src/main/scala/devices/i2c/I2CPins.scala
+++ b/src/main/scala/devices/i2c/I2CPins.scala
@@ -15,7 +15,7 @@ class I2CPins[T <: Pin](pingen: () => T) extends Bundle {
   override def cloneType: this.type =
     this.getClass.getConstructors.head.newInstance(pingen).asInstanceOf[this.type]
 
-  def fromI2CPort(i2c: I2CPort, clock: Clock, reset: Bool, syncStages: Int = 0) = {
+  def fromPort(i2c: I2CPort, clock: Clock, reset: Bool, syncStages: Int = 0) = {
     withClockAndReset(clock, reset) {
       scl.outputPin(i2c.scl.out, pue=true.B, ie = true.B)
       scl.o.oe := i2c.scl.oe

--- a/src/main/scala/devices/i2c/I2CPins.scala
+++ b/src/main/scala/devices/i2c/I2CPins.scala
@@ -2,6 +2,7 @@
 package sifive.blocks.devices.i2c
 
 import Chisel._
+import chisel3.experimental.{withClockAndReset}
 import sifive.blocks.devices.pinctrl.{Pin, PinCtrl}
 import sifive.blocks.util.ShiftRegisterInit
 
@@ -11,13 +12,15 @@ class I2CPins[T <: Pin](pingen: () => T) extends Bundle {
   val scl: T = pingen()
   val sda: T = pingen()
 
-  def fromI2CPort(i2c: I2CPort, syncStages: Int = 0) = {
-    scl.outputPin(i2c.scl.out, pue=true.B, ie = true.B)
-    scl.o.oe := i2c.scl.oe
-    i2c.scl.in := ShiftRegisterInit(scl.i.ival, syncStages, Bool(true))
+  def fromI2CPort(i2c: I2CPort, clock: Clock, reset: Bool, syncStages: Int = 0) = {
+    withClockAndReset(clock, reset) {
+      scl.outputPin(i2c.scl.out, pue=true.B, ie = true.B)
+      scl.o.oe := i2c.scl.oe
+      i2c.scl.in := ShiftRegisterInit(scl.i.ival, syncStages, Bool(true))
 
-    sda.outputPin(i2c.sda.out, pue=true.B, ie = true.B)
-    sda.o.oe := i2c.sda.oe
-    i2c.sda.in := ShiftRegisterInit(sda.i.ival, syncStages, Bool(true))
+      sda.outputPin(i2c.sda.out, pue=true.B, ie = true.B)
+      sda.o.oe := i2c.sda.oe
+      i2c.sda.in := ShiftRegisterInit(sda.i.ival, syncStages, Bool(true))
+    }
   }
 }

--- a/src/main/scala/devices/i2c/I2CPins.scala
+++ b/src/main/scala/devices/i2c/I2CPins.scala
@@ -2,26 +2,22 @@
 package sifive.blocks.devices.i2c
 
 import Chisel._
-import sifive.blocks.devices.gpio.{GPIOPin, GPIOOutputPinCtrl}
+import sifive.blocks.devices.pinctrl.{Pin, PinCtrl}
 import sifive.blocks.util.ShiftRegisterInit
 
 
-class I2CPinsIO extends Bundle {
-  val scl = new GPIOPin
-  val sda = new GPIOPin
-}
+class I2CPins[T <: Pin](pingen: () => T) extends Bundle {
 
-class I2CGPIOPort(syncStages: Int = 0) extends Module {
-  val io = new Bundle{
-    val i2c = new I2CPort().flip()
-    val pins = new I2CPinsIO
+  val scl: T = pingen()
+  val sda: T = pingen()
+
+  def fromI2CPort(i2c: I2CPort, syncStages: Int = 0) = {
+    scl.outputPin(i2c.scl.out, pue=true.B, ie = true.B)
+    scl.o.oe := i2c.scl.oe
+    i2c.scl.in := ShiftRegisterInit(scl.i.ival, syncStages, Bool(true))
+
+    sda.outputPin(i2c.sda.out, pue=true.B, ie = true.B)
+    sda.o.oe := i2c.sda.oe
+    i2c.sda.in := ShiftRegisterInit(sda.i.ival, syncStages, Bool(true))
   }
-
-  GPIOOutputPinCtrl(io.pins.scl, io.i2c.scl.out, pue=true.B, ie = true.B)
-  io.pins.scl.o.oe := io.i2c.scl.oe
-  io.i2c.scl.in := ShiftRegisterInit(io.pins.scl.i.ival, syncStages, Bool(true))
-
-  GPIOOutputPinCtrl(io.pins.sda, io.i2c.sda.out, pue=true.B, ie = true.B)
-  io.pins.sda.o.oe := io.i2c.sda.oe
-  io.i2c.sda.in := ShiftRegisterInit(io.pins.sda.i.ival, syncStages, Bool(true))
 }

--- a/src/main/scala/devices/jtag/JTAGPins.scala
+++ b/src/main/scala/devices/jtag/JTAGPins.scala
@@ -1,13 +1,12 @@
 // See LICENSE for license details.
-package sifive.blocks.devices.gpio
+package sifive.blocks.devices.jtag
 
 import Chisel._
 
 // ------------------------------------------------------------
-// SPI, UART, etc are with their
-// respective packages,
-// This file is for those that don't seem to have a good place
-// to put them otherwise.
+// SPI, UART, etc are with their respective packages,
+// JTAG doesn't really correspond directly to a device, but it does
+// define pins as those devices do.
 // ------------------------------------------------------------
 
 import freechips.rocketchip.config._
@@ -22,7 +21,7 @@ class JTAGPins[T <: Pin](pingen: () => T, hasTRSTn: Boolean = true) extends Bund
   val TDO        = pingen()
   val TRSTn = if (hasTRSTn) Option(pingen()) else None
 
-  def fromJTAGPort(jtag: JTAGIO): Unit = {
+  def fromPort(jtag: JTAGIO): Unit = {
     jtag.TCK  := TCK.inputPin (pue = Bool(true)).asClock
     jtag.TMS  := TMS.inputPin (pue = Bool(true))
     jtag.TDI  := TDI.inputPin(pue = Bool(true))

--- a/src/main/scala/devices/mockaon/MockAONWrapper.scala
+++ b/src/main/scala/devices/mockaon/MockAONWrapper.scala
@@ -24,7 +24,7 @@ class MockAONWrapperPins extends Bundle {
 }
 
 class MockAONWrapperBundle extends Bundle {
-  val pads = new MockAONWrapperPins()
+  val pins = new MockAONWrapperPins()
   val rsts = new MockAONMOffRstIO()
 }
 
@@ -61,14 +61,14 @@ class MockAONWrapper(w: Int, c: MockAONParams)(implicit p: Parameters) extends L
     }
 
     val aon_io = aon.module.io
-    val pads = io.pads
+    val pins = io.pins
 
     // -----------------------------------------------
     // Generation of aonrst
     // -----------------------------------------------
 
     // ERST
-    val erst = ~pads.erst_n.inputPin(pue = Bool(true))
+    val erst = ~pins.erst_n.inputPin(pue = Bool(true))
     aon_io.resetCauses.erst := erst
     aon_io.resetCauses.wdogrst := aon_io.wdog_rst
 
@@ -94,7 +94,7 @@ class MockAONWrapper(w: Int, c: MockAONParams)(implicit p: Parameters) extends L
     // Note that the actual mux lives inside AON itself.
     // Therefore, the lfclk which comes out of AON is the
     // true clock that AON and AONWrapper are running off of.
-    val lfextclk = pads.lfextclk.inputPin(pue=Bool(true))
+    val lfextclk = pins.lfextclk.inputPin(pue=Bool(true))
     aon_io.lfextclk := lfextclk.asClock
 
     // Drive AON's clock and Reset
@@ -133,17 +133,17 @@ class MockAONWrapper(w: Int, c: MockAONParams)(implicit p: Parameters) extends L
     isolation.module.io.iso_in  := Bool(true)
 
     //--------------------------------------------------
-    // PMU <--> pads Interface
+    // PMU <--> pins Interface
     //--------------------------------------------------
 
-    val dwakeup_n_async = pads.pmu.dwakeup_n.inputPin(pue=Bool(true))
+    val dwakeup_n_async = pins.pmu.dwakeup_n.inputPin(pue=Bool(true))
 
     val dwakeup_deglitch = Module (new DeglitchShiftRegister(3))
     dwakeup_deglitch.clock := lfclk
     dwakeup_deglitch.io.d := ~dwakeup_n_async
     aon.module.io.pmu.dwakeup := dwakeup_deglitch.io.q
 
-    pads.pmu.vddpaden.outputPin(aon.module.io.pmu.vddpaden)
+    pins.pmu.vddpaden.outputPin(aon.module.io.pmu.vddpaden)
 
     //--------------------------------------------------
     // Connect signals to MOFF

--- a/src/main/scala/devices/mockaon/MockAONWrapper.scala
+++ b/src/main/scala/devices/mockaon/MockAONWrapper.scala
@@ -17,14 +17,14 @@ class MockAONWrapperPMUIO extends Bundle {
   val vddpaden = new  EnhancedPin()
 }
 
-class MockAONWrapperPadsIO extends Bundle {
+class MockAONWrapperPins extends Bundle {
   val erst_n   = new EnhancedPin()
   val lfextclk = new EnhancedPin()
   val pmu = new MockAONWrapperPMUIO()
 }
 
 class MockAONWrapperBundle extends Bundle {
-  val pads = new MockAONWrapperPadsIO()
+  val pads = new MockAONWrapperPins()
   val rsts = new MockAONMOffRstIO()
 }
 

--- a/src/main/scala/devices/pinctrl/PinCtrl.scala
+++ b/src/main/scala/devices/pinctrl/PinCtrl.scala
@@ -21,6 +21,7 @@ abstract class Pin extends Bundle {
   val o: PinCtrl
 
   // Must be defined by the subclasses
+  def default(): Unit
   def inputPin(pue: Bool = Bool(false)): Bool
   def outputPin(signal: Bool,
     pue: Bool = Bool(false),
@@ -28,13 +29,6 @@ abstract class Pin extends Bundle {
     ie: Bool = Bool(false)
   ): Unit
   
-  def inputPin(pins: Vec[this.type], pue: Bool): Vec[Bool] = {
-    val signals = Wire(Vec(pins.length, new Bool()))
-    for ((signal, pin) <- (signals zip pins)) {
-      signal := pin.inputPin(pue)
-    }
-    signals
-  }
 }
 
 
@@ -42,6 +36,12 @@ abstract class Pin extends Bundle {
 
 class BasePin extends Pin() {
   val o = new PinCtrl().asOutput
+
+  def default(): Unit = {
+    this.o.oval := Bool(false)
+    this.o.oe   := Bool(false)
+    this.o.ie   := Bool(false)
+  }
 
   def inputPin(pue: Bool = Bool(false) /*ignored*/): Bool = {
     this.o.oval := Bool(false)
@@ -59,7 +59,6 @@ class BasePin extends Pin() {
     this.o.oe   := Bool(true)
     this.o.ie   := ie
   }
-
 }
 
 /////////////////////////////////////////////////////////////////////////
@@ -71,6 +70,14 @@ class EnhancedPinCtrl extends PinCtrl {
 class EnhancedPin extends Pin() {
 
   val o = new EnhancedPinCtrl().asOutput
+
+  def default(): Unit = {
+    this.o.oval := Bool(false)
+    this.o.oe   := Bool(false)
+    this.o.ie   := Bool(false)
+    this.o.ds   := Bool(false)
+    this.o.pue  := Bool(false)
+  }
 
   def inputPin(pue: Bool = Bool(false)): Bool = {
     this.o.oval := Bool(false)

--- a/src/main/scala/devices/pinctrl/PinCtrl.scala
+++ b/src/main/scala/devices/pinctrl/PinCtrl.scala
@@ -1,0 +1,96 @@
+//See LICENSE for license details
+
+package sifive.blocks.devices.pinctrl
+
+import Chisel._
+
+// This is the base class of things you "always"
+// want to control from a HW block.
+class PinCtrl extends Bundle {
+  val oval = Bool()
+  val oe   = Bool()
+  val ie   = Bool()
+}
+
+// Package up the inputs and outputs
+// for the Pin
+abstract class Pin extends Bundle {
+  val i = new Bundle {
+    val ival = Bool(INPUT)
+  }
+  val o: PinCtrl
+
+  // Must be defined by the subclasses
+  def inputPin(pue: Bool = Bool(false)): Bool
+  def outputPin(signal: Bool,
+    pue: Bool = Bool(false),
+    ds: Bool = Bool(false),
+    ie: Bool = Bool(false)
+  ): Unit
+  
+  def inputPin(pins: Vec[this.type], pue: Bool): Vec[Bool] = {
+    val signals = Wire(Vec(pins.length, new Bool()))
+    for ((signal, pin) <- (signals zip pins)) {
+      signal := pin.inputPin(pue)
+    }
+    signals
+  }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////
+
+class BasePin extends Pin() {
+  val o = new PinCtrl().asOutput
+
+  def inputPin(pue: Bool = Bool(false) /*ignored*/): Bool = {
+    this.o.oval := Bool(false)
+    this.o.oe   := Bool(false)
+    this.o.ie   := Bool(true)
+    this.i.ival
+  }
+
+  def outputPin(signal: Bool,
+    pue: Bool = Bool(false), /*ignored*/
+    ds: Bool = Bool(false), /*ignored*/
+    ie: Bool = Bool(false)
+  ): Unit = {
+    this.o.oval := signal
+    this.o.oe   := Bool(true)
+    this.o.ie   := ie
+  }
+
+}
+
+/////////////////////////////////////////////////////////////////////////
+class EnhancedPinCtrl extends PinCtrl {
+  val pue = Bool()
+  val ds = Bool()
+}
+
+class EnhancedPin extends Pin() {
+
+  val o = new EnhancedPinCtrl().asOutput
+
+  def inputPin(pue: Bool = Bool(false)): Bool = {
+    this.o.oval := Bool(false)
+    this.o.oe   := Bool(false)
+    this.o.pue  := pue
+    this.o.ds   := Bool(false)
+    this.o.ie   := Bool(true)
+
+    this.i.ival
+  }
+
+  def outputPin(signal: Bool,
+    pue: Bool = Bool(false),
+    ds: Bool = Bool(false),
+    ie: Bool = Bool(false)
+  ): Unit = {
+    this.o.oval := signal
+    this.o.oe   := Bool(true)
+    this.o.pue  := pue
+    this.o.ds   := ds
+    this.o.ie   := ie
+  }
+}

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -38,15 +38,15 @@ trait HasPeripheryPWM extends HasSystemNetworks {
 }
 
 trait HasPeripheryPWMBundle {
-  val pwms: HeterogeneousBag[PWMPortIO]
+  val pwm: HeterogeneousBag[PWMPortIO]
 
 }
 
 trait HasPeripheryPWMModuleImp extends LazyMultiIOModuleImp with HasPeripheryPWMBundle {
   val outer: HasPeripheryPWM
-  val pwms = IO(HeterogeneousBag(outer.pwmParams.map(new PWMPortIO(_))))
+  val pwm = IO(HeterogeneousBag(outer.pwmParams.map(new PWMPortIO(_))))
 
-  (pwms zip outer.pwms) foreach { case (io, device) =>
+  (pwm zip outer.pwms) foreach { case (io, device) =>
     io.port := device.module.io.gpio
   }
 }

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -18,6 +18,9 @@ class PWMPins[T <: Pin] (pingen: ()=> T, val c: PWMParams) extends Bundle {
 
   val pwm: Vec[T] = Vec(c.ncmp, pingen())
 
+  override def cloneType: this.type =
+    this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
+
   def fromPWMPort(port: PWMPortIO) {
     (pwm zip port.port)  foreach {case (pin, port) =>
       pin.outputPin(port)

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -20,7 +20,7 @@ class PWMPins[T <: Pin] (pingen: ()=> T, val c: PWMParams) extends Bundle {
   override def cloneType: this.type =
     this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
 
-  def fromPWMPort(port: PWMPortIO) {
+  def fromPort(port: PWMPortIO) {
     (pwm zip port.port)  foreach {case (pin, port) =>
       pin.outputPin(port)
     }

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -23,11 +23,6 @@ trait HasPeripherySPI extends HasSystemNetworks {
 trait HasPeripherySPIBundle {
   val spis: HeterogeneousBag[SPIPortIO]
 
-  def SPItoGPIOPins(syncStages: Int = 0): Seq[SPIPinsIO] = spis.map { s =>
-    val pins = Module(new SPIGPIOPort(s.c, syncStages))
-    pins.io.spi <> s
-    pins.io.pins
-  }
 }
 
 trait HasPeripherySPIModuleImp extends LazyMultiIOModuleImp with HasPeripherySPIBundle {
@@ -55,14 +50,6 @@ trait HasPeripherySPIFlash extends HasSystemNetworks {
 trait HasPeripherySPIFlashBundle {
   val qspi: HeterogeneousBag[SPIPortIO]
 
-  // It is important for SPIFlash that the syncStages is agreed upon, because
-  // internally it needs to realign the input data to the output SCK.
-  // Therefore, we rely on the syncStages parameter.
-  def SPIFlashtoGPIOPins(syncStages: Int = 0): Seq[SPIPinsIO] = qspi.map { s =>
-    val pins = Module(new SPIGPIOPort(s.c, syncStages))
-    pins.io.spi <> s
-    pins.io.pins
-  }
 }
 
 trait HasPeripherySPIFlashModuleImp extends LazyMultiIOModuleImp with HasPeripherySPIFlashBundle {

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -21,15 +21,15 @@ trait HasPeripherySPI extends HasSystemNetworks {
 }
 
 trait HasPeripherySPIBundle {
-  val spis: HeterogeneousBag[SPIPortIO]
+  val spi: HeterogeneousBag[SPIPortIO]
 
 }
 
 trait HasPeripherySPIModuleImp extends LazyMultiIOModuleImp with HasPeripherySPIBundle {
   val outer: HasPeripherySPI
-  val spis = IO(HeterogeneousBag(outer.spiParams.map(new SPIPortIO(_))))
+  val spi = IO(HeterogeneousBag(outer.spiParams.map(new SPIPortIO(_))))
 
-  (spis zip outer.spis).foreach { case (io, device) =>
+  (spi zip outer.spis).foreach { case (io, device) =>
     io <> device.module.io.port
   }
 }
@@ -38,7 +38,7 @@ case object PeripherySPIFlashKey extends Field[Seq[SPIFlashParams]]
 
 trait HasPeripherySPIFlash extends HasSystemNetworks {
   val spiFlashParams = p(PeripherySPIFlashKey)  
-  val qspi = spiFlashParams map { params =>
+  val qspis = spiFlashParams map { params =>
     val qspi = LazyModule(new TLSPIFlash(peripheryBusBytes, params))
     qspi.rnode := TLFragmenter(peripheryBusBytes, cacheBlockBytes)(peripheryBus.node)
     qspi.fnode := TLFragmenter(1, cacheBlockBytes)(TLWidthWidget(peripheryBusBytes)(peripheryBus.node))
@@ -56,7 +56,7 @@ trait HasPeripherySPIFlashModuleImp extends LazyMultiIOModuleImp with HasPeriphe
   val outer: HasPeripherySPIFlash
   val qspi = IO(HeterogeneousBag(outer.spiFlashParams.map(new SPIPortIO(_))))
 
-  (qspi zip outer.qspi) foreach { case (io, device) => 
+  (qspi zip outer.qspis) foreach { case (io, device) => 
     io <> device.module.io.port
   }
 }

--- a/src/main/scala/devices/spi/SPIPins.scala
+++ b/src/main/scala/devices/spi/SPIPins.scala
@@ -7,9 +7,12 @@ import sifive.blocks.devices.pinctrl.{PinCtrl, Pin}
 
 class SPIPins[T <: Pin] (pingen: ()=> T, c: SPIParamsBase) extends SPIBundle(c) {
 
-  val sck: T      = pingen()
-  val dq: Vec[T]  = Vec(4, pingen())
-  val cs: Vec[T]  = Vec(c.csWidth, pingen())
+  val sck = pingen()
+  val dq  = Vec(4, pingen())
+  val cs  = Vec(c.csWidth, pingen())
+
+  override def cloneType: this.type =
+    this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
 
   def fromSPIPort(spi: SPIPortIO, clock: Clock, reset: Bool,
     syncStages: Int = 0, driveStrength: Bool = Bool(false)) {

--- a/src/main/scala/devices/spi/SPIPins.scala
+++ b/src/main/scala/devices/spi/SPIPins.scala
@@ -2,33 +2,27 @@
 package sifive.blocks.devices.spi
 
 import Chisel._
-import sifive.blocks.devices.gpio.{GPIOPin, GPIOOutputPinCtrl, GPIOInputPinCtrl}
+import sifive.blocks.devices.pinctrl.{PinCtrl, Pin}
 
-class SPIPinsIO(c: SPIParamsBase) extends SPIBundle(c) {
-  val sck = new GPIOPin
-  val dq = Vec(4, new GPIOPin)
-  val cs = Vec(c.csWidth, new GPIOPin)
-}
+class SPIPins[T <: Pin] (pingen: ()=> T, c: SPIParamsBase) extends SPIBundle(c) {
 
-class SPIGPIOPort(c: SPIParamsBase, syncStages: Int = 0, driveStrength: Bool = Bool(false)) extends Module {
-  val io = new SPIBundle(c) {
-    val spi = new SPIPortIO(c).flip
-    val pins = new SPIPinsIO(c)
-  }
+  val sck: T      = pingen()
+  val dq: Vec[T]  = Vec(4, pingen())
+  val cs: Vec[T]  = Vec(c.csWidth, pingen())
 
-  GPIOOutputPinCtrl(io.pins.sck, io.spi.sck, ds = driveStrength)
+  def fromSPIPort(spi: SPIPortIO, syncStages: Int = 0, driveStrength: Bool = Bool(false)) {
+    
+    sck.outputPin(spi.sck, ds = driveStrength)
 
-  GPIOOutputPinCtrl(io.pins.dq, Bits(0, io.spi.dq.size))
-  (io.pins.dq zip io.spi.dq).foreach {
-    case (p, s) =>
-      p.o.oval := s.o
-      p.o.oe  := s.oe
-      p.o.ie  := ~s.oe
-      p.o.pue := Bool(true)
-      p.o.ds  := driveStrength
+    (dq zip spi.dq).foreach {case (p, s) =>
+      p.outputPin(s.o, pue = Bool(true), ds = driveStrength)
+      p.o.oe := s.oe
+      p.o.ie := ~s.oe
       s.i := ShiftRegister(p.i.ival, syncStages)
-  }
+    }
 
-  GPIOOutputPinCtrl(io.pins.cs, io.spi.cs.asUInt)
-  io.pins.cs.foreach(_.o.ds := driveStrength)
+    (cs zip spi.cs) foreach { case (c, s) =>
+      c.outputPin(s, ds = driveStrength)
+    }
+  }
 }

--- a/src/main/scala/devices/spi/SPIPins.scala
+++ b/src/main/scala/devices/spi/SPIPins.scala
@@ -2,6 +2,7 @@
 package sifive.blocks.devices.spi
 
 import Chisel._
+import chisel3.experimental.{withClockAndReset}
 import sifive.blocks.devices.pinctrl.{PinCtrl, Pin}
 
 class SPIPins[T <: Pin] (pingen: ()=> T, c: SPIParamsBase) extends SPIBundle(c) {
@@ -10,19 +11,22 @@ class SPIPins[T <: Pin] (pingen: ()=> T, c: SPIParamsBase) extends SPIBundle(c) 
   val dq: Vec[T]  = Vec(4, pingen())
   val cs: Vec[T]  = Vec(c.csWidth, pingen())
 
-  def fromSPIPort(spi: SPIPortIO, syncStages: Int = 0, driveStrength: Bool = Bool(false)) {
-    
-    sck.outputPin(spi.sck, ds = driveStrength)
+  def fromSPIPort(spi: SPIPortIO, clock: Clock, reset: Bool,
+    syncStages: Int = 0, driveStrength: Bool = Bool(false)) {
 
-    (dq zip spi.dq).foreach {case (p, s) =>
-      p.outputPin(s.o, pue = Bool(true), ds = driveStrength)
-      p.o.oe := s.oe
-      p.o.ie := ~s.oe
-      s.i := ShiftRegister(p.i.ival, syncStages)
-    }
+    withClockAndReset(clock, reset) {
+      sck.outputPin(spi.sck, ds = driveStrength)
 
-    (cs zip spi.cs) foreach { case (c, s) =>
-      c.outputPin(s, ds = driveStrength)
+      (dq zip spi.dq).foreach {case (p, s) =>
+        p.outputPin(s.o, pue = Bool(true), ds = driveStrength)
+        p.o.oe := s.oe
+        p.o.ie := ~s.oe
+        s.i := ShiftRegister(p.i.ival, syncStages)
+      }
+
+      (cs zip spi.cs) foreach { case (c, s) =>
+        c.outputPin(s, ds = driveStrength)
+      }
     }
   }
 }

--- a/src/main/scala/devices/spi/SPIPins.scala
+++ b/src/main/scala/devices/spi/SPIPins.scala
@@ -14,7 +14,7 @@ class SPIPins[T <: Pin] (pingen: ()=> T, c: SPIParamsBase) extends SPIBundle(c) 
   override def cloneType: this.type =
     this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
 
-  def fromSPIPort(spi: SPIPortIO, clock: Clock, reset: Bool,
+  def fromPort(spi: SPIPortIO, clock: Clock, reset: Bool,
     syncStages: Int = 0, driveStrength: Bool = Bool(false)) {
 
     withClockAndReset(clock, reset) {

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -44,6 +44,9 @@ class UARTPins[T <: Pin] (pingen: () => T) extends Bundle {
   val rxd = pingen()
   val txd = pingen()
 
+  override def cloneType: this.type =
+    this.getClass.getConstructors.head.newInstance(pingen).asInstanceOf[this.type]
+
   def fromUARTPort(uart: UARTPortIO, clock: Clock, reset: Bool, syncStages: Int = 0) {
     withClockAndReset(clock, reset) {
       txd.outputPin(uart.txd)

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -47,7 +47,7 @@ class UARTPins[T <: Pin] (pingen: () => T) extends Bundle {
   override def cloneType: this.type =
     this.getClass.getConstructors.head.newInstance(pingen).asInstanceOf[this.type]
 
-  def fromUARTPort(uart: UARTPortIO, clock: Clock, reset: Bool, syncStages: Int = 0) {
+  def fromPort(uart: UARTPortIO, clock: Clock, reset: Bool, syncStages: Int = 0) {
     withClockAndReset(clock, reset) {
       txd.outputPin(uart.txd)
       val rxd_t = rxd.inputPin()


### PR DESCRIPTION
This also standardizes some pluralization. Bundle names (e.g. spi) is not pluralized. Inside the modules, the peripherals themselves are pluralized. This also helps avoid name conflicts.