### PR TITLE
Allow bundle content params to be specified via a def

### DIFF
--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -82,7 +82,7 @@ class GPIOPortIO(c: GPIOParams) extends GenericParameterizedBundle(c) {
 // It would be better if the IOF were here and
 // we could do the pinmux inside.
 trait HasGPIOBundleContents extends Bundle {
-  val params: GPIOParams
+  def params: GPIOParams
   val port = new GPIOPortIO(params)
 }
 

--- a/src/main/scala/devices/pwm/PWM.scala
+++ b/src/main/scala/devices/pwm/PWM.scala
@@ -44,7 +44,7 @@ case class PWMParams(
   cmpWidth: Int = 16)
 
 trait HasPWMBundleContents extends Bundle {
-  val params: PWMParams
+  def params: PWMParams
   val gpio = Vec(params.ncmp, Bool()).asOutput
 }
 

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -12,10 +12,10 @@ import sifive.blocks.util.ShiftRegisterInit
 case object PeripheryUARTKey extends Field[Seq[UARTParams]]
 
 trait HasPeripheryUART extends HasPeripheryBus with HasInterruptBus {
-  val uartParams = p(PeripheryUARTKey)
-  val divinit = (p(PeripheryBusParams).frequency / 115200).toInt
+  private val divinit = (p(PeripheryBusParams).frequency / 115200).toInt
+  val uartParams = p(PeripheryUARTKey).map(_.copy(divisorInit = divinit))
   val uarts = uartParams map { params =>
-    val uart = LazyModule(new TLUART(pbus.beatBytes, params.copy(divisorInit = divinit)))
+    val uart = LazyModule(new TLUART(pbus.beatBytes, params))
     uart.node := pbus.toVariableWidthSlaves
     ibus.fromSync := uart.intnode
     uart


### PR DESCRIPTION
Makes it easier to supply bundle params from different sources without worrying about trait mix-in order.

Also clean up the calculation of UART divinit