### PR TITLE
mockaon: Adds logic to detect external rtc toggles

### DIFF
--- a/src/main/scala/devices/mockaon/MockAONPeriphery.scala
+++ b/src/main/scala/devices/mockaon/MockAONPeriphery.scala
@@ -42,7 +42,12 @@ trait HasPeripheryMockAONModuleImp extends LazyMultiIOModuleImp with HasPeripher
   outer.aon.module.clock := Bool(false).asClock
   outer.aon.module.reset := Bool(true)
 
-  outer.clint.module.io.rtcTick := outer.aon.module.io.rtc.asUInt.toBool
+  // Synchronize the external toggle into the clint
+  val rtc_sync = ShiftRegister(outer.aon.module.io.rtc.asUInt.toBool, 3)
+  val rtc_last = Reg(init = Bool(false), next=rtc_sync)
+  val rtc_tick = Reg(init = Bool(false), next=(rtc_sync & (~rtc_last)))
+
+  outer.clint.module.io.rtcTick := rtc_tick
 
   outer.aon.module.io.ndreset := outer.debug.module.io.ctrl.ndreset
 }


### PR DESCRIPTION
This commit adds the logic to detect the external rtc toggles which was previously present in rocket-chip