### PR TITLE
Create Signal Bundles vs just Pins

### DIFF
--- a/src/main/scala/devices/gpio/GPIOPins.scala
+++ b/src/main/scala/devices/gpio/GPIOPins.scala
@@ -11,9 +11,15 @@ import sifive.blocks.devices.pinctrl.{Pin}
 // type of pad this connects to.
 class GPIOSignals[T <: Data] (pingen: ()=> T,  c: GPIOParams) extends Bundle {
   val pins = Vec(c.width, pingen())
+
+  override def cloneType: this.type =
+    this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
 }
 
-class GPIOPins[T <: Pin] (pingen: ()=> T,  c: GPIOParams) extends GPIOSignals[T](pingen, c)
+class GPIOPins[T <: Pin] (pingen: ()=> T,  c: GPIOParams) extends GPIOSignals[T](pingen, c) {
+  override def cloneType: this.type =
+    this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
+}
 
 object GPIOPinsFromPort {
 

--- a/src/main/scala/devices/gpio/GPIOPins.scala
+++ b/src/main/scala/devices/gpio/GPIOPins.scala
@@ -9,18 +9,19 @@ import sifive.blocks.devices.pinctrl.{Pin}
 // even though it looks like something that more directly talks to
 // a pin. It also makes it possible to change the exact
 // type of pad this connects to.
-class GPIOPins[T <: Pin] (pingen: ()=> T,  c: GPIOParams) extends Bundle {
-
+class GPIOSignals[T <: Data] (pingen: ()=> T,  c: GPIOParams) extends Bundle {
   val pins = Vec(c.width, pingen())
+}
 
-  override def cloneType: this.type =
-    this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
+class GPIOPins[T <: Pin] (pingen: ()=> T,  c: GPIOParams) extends GPIOSignals[T](pingen, c)
 
-  def fromPort(port: GPIOPortIO){
+object GPIOPinsFromPort {
+
+  def apply[T <: Pin](pins: GPIOSignals[T], port: GPIOPortIO){
 
     // This will just match up the components of the Bundle that
     // exist in both.
-    (pins zip port.pins) foreach {case (pin, port) =>
+    (pins.pins zip port.pins) foreach {case (pin, port) =>
       pin <> port
     }
   }

--- a/src/main/scala/devices/i2c/I2CPins.scala
+++ b/src/main/scala/devices/i2c/I2CPins.scala
@@ -6,11 +6,16 @@ import chisel3.experimental.{withClockAndReset}
 import freechips.rocketchip.util.SyncResetSynchronizerShiftReg
 import sifive.blocks.devices.pinctrl.{Pin, PinCtrl}
 
-class I2CPins[T <: Pin](pingen: () => T) extends Bundle {
+class I2CSignals[T <: Data](pingen: () => T) extends Bundle {
 
   val scl: T = pingen()
   val sda: T = pingen()
 
+  override def cloneType: this.type =
+    this.getClass.getConstructors.head.newInstance(pingen).asInstanceOf[this.type]
+}
+
+class I2CPins[T <: Pin](pingen: () => T) extends I2CSignals[T](pingen) {
   override def cloneType: this.type =
     this.getClass.getConstructors.head.newInstance(pingen).asInstanceOf[this.type]
 

--- a/src/main/scala/devices/i2c/I2CPins.scala
+++ b/src/main/scala/devices/i2c/I2CPins.scala
@@ -15,20 +15,20 @@ class I2CSignals[T <: Data](pingen: () => T) extends Bundle {
     this.getClass.getConstructors.head.newInstance(pingen).asInstanceOf[this.type]
 }
 
-class I2CPins[T <: Pin](pingen: () => T) extends I2CSignals[T](pingen) {
-  override def cloneType: this.type =
-    this.getClass.getConstructors.head.newInstance(pingen).asInstanceOf[this.type]
+class I2CPins[T <: Pin](pingen: () => T) extends I2CSignals[T](pingen)
 
-  def fromPort(i2c: I2CPort, clock: Clock, reset: Bool, syncStages: Int = 0) = {
+object I2CPinsFromPort {
+
+  def apply[T <: Pin](pins: I2CSignals[T], i2c: I2CPort, clock: Clock, reset: Bool, syncStages: Int = 0) = {
     withClockAndReset(clock, reset) {
-      scl.outputPin(i2c.scl.out, pue=true.B, ie = true.B)
-      scl.o.oe := i2c.scl.oe
-      i2c.scl.in := SyncResetSynchronizerShiftReg(scl.i.ival, syncStages, init = Bool(true),
+      pins.scl.outputPin(i2c.scl.out, pue=true.B, ie = true.B)
+      pins.scl.o.oe := i2c.scl.oe
+      i2c.scl.in := SyncResetSynchronizerShiftReg(pins.scl.i.ival, syncStages, init = Bool(true),
         name = Some("i2c_scl_sync"))
 
-      sda.outputPin(i2c.sda.out, pue=true.B, ie = true.B)
-      sda.o.oe := i2c.sda.oe
-      i2c.sda.in := SyncResetSynchronizerShiftReg(sda.i.ival, syncStages, init = Bool(true),
+      pins.sda.outputPin(i2c.sda.out, pue=true.B, ie = true.B)
+      pins.sda.o.oe := i2c.sda.oe
+      i2c.sda.in := SyncResetSynchronizerShiftReg(pins.sda.i.ival, syncStages, init = Bool(true),
         name = Some("i2c_sda_sync"))
     }
   }

--- a/src/main/scala/devices/jtag/JTAGPins.scala
+++ b/src/main/scala/devices/jtag/JTAGPins.scala
@@ -13,21 +13,25 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.jtag.{JTAGIO}
 import sifive.blocks.devices.pinctrl.{Pin, PinCtrl}
 
-class JTAGPins[T <: Pin](pingen: () => T, hasTRSTn: Boolean = true) extends Bundle {
-
+class JTAGSignals[T <: Data](pingen: () => T, hasTRSTn: Boolean = true) extends Bundle {
   val TCK         = pingen()
   val TMS         = pingen()
   val TDI         = pingen()
   val TDO        = pingen()
   val TRSTn = if (hasTRSTn) Option(pingen()) else None
+}
 
-  def fromPort(jtag: JTAGIO): Unit = {
-    jtag.TCK  := TCK.inputPin (pue = Bool(true)).asClock
-    jtag.TMS  := TMS.inputPin (pue = Bool(true))
-    jtag.TDI  := TDI.inputPin(pue = Bool(true))
-    jtag.TRSTn.foreach{t => t := TRSTn.get.inputPin(pue = Bool(true))}
+class JTAGPins[T <: Pin](pingen: () => T, hasTRSTn: Boolean = true) extends JTAGSignals[T](pingen, hasTRSTn)
 
-    TDO.outputPin(jtag.TDO.data)
-    TDO.o.oe := jtag.TDO.driven
+object JTAGPinsFromPort {
+
+  def apply[T <: Pin] (pins: JTAGSignals[T], jtag: JTAGIO): Unit = {
+    jtag.TCK  := pins.TCK.inputPin (pue = Bool(true)).asClock
+    jtag.TMS  := pins.TMS.inputPin (pue = Bool(true))
+    jtag.TDI  := pins.TDI.inputPin(pue = Bool(true))
+    jtag.TRSTn.foreach{t => t := pins.TRSTn.get.inputPin(pue = Bool(true))}
+
+    pins.TDO.outputPin(jtag.TDO.data)
+    pins.TDO.o.oe := jtag.TDO.driven
   }
 }

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -13,26 +13,6 @@ class PWMPortIO(val c: PWMParams) extends Bundle {
   override def cloneType: this.type = new PWMPortIO(c).asInstanceOf[this.type]
 }
 
-class PWMSignals[T <: Data] (pingen: ()=> T, val c: PWMParams) extends Bundle {
-
-  val pwm: Vec[T] = Vec(c.ncmp, pingen())
-
-  override def cloneType: this.type =
-    this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
-}
-
-
-class PWMPins[T <: Pin] (pingen: ()=> T, val c: PWMParams) extends PWMSignals[T](pingen, c) {
-
-  override def cloneType: this.type =
-    this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
-
-  def fromPort(port: PWMPortIO) {
-    (pwm zip port.port)  foreach {case (pin, port) =>
-      pin.outputPin(port)
-    }
-  }
-}
 
 case object PeripheryPWMKey extends Field[Seq[PWMParams]]
 

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -13,9 +13,16 @@ class PWMPortIO(val c: PWMParams) extends Bundle {
   override def cloneType: this.type = new PWMPortIO(c).asInstanceOf[this.type]
 }
 
-class PWMPins[T <: Pin] (pingen: ()=> T, val c: PWMParams) extends Bundle {
+class PWMSignals[T <: Data] (pingen: ()=> T, val c: PWMParams) extends Bundle {
 
   val pwm: Vec[T] = Vec(c.ncmp, pingen())
+
+  override def cloneType: this.type =
+    this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
+}
+
+
+class PWMPins[T <: Pin] (pingen: ()=> T, val c: PWMParams) extends PWMSignals[T](pingen, c) {
 
   override def cloneType: this.type =
     this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]

--- a/src/main/scala/devices/pwm/PWMPins.scala
+++ b/src/main/scala/devices/pwm/PWMPins.scala
@@ -1,0 +1,27 @@
+// See LICENSE for license details.
+package sifive.blocks.devices.pwm
+
+import Chisel._
+import freechips.rocketchip.config.Field
+import freechips.rocketchip.coreplex.{HasPeripheryBus, HasInterruptBus}
+import freechips.rocketchip.diplomacy.{LazyModule, LazyMultiIOModuleImp}
+import freechips.rocketchip.util.HeterogeneousBag
+import sifive.blocks.devices.pinctrl.{Pin}
+
+class PWMSignals[T <: Data] (pingen: ()=> T, val c: PWMParams) extends Bundle {
+
+  val pwm: Vec[T] = Vec(c.ncmp, pingen())
+
+  override def cloneType: this.type =
+    this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
+}
+
+class PWMPins[T <: Pin] (pingen: ()=> T, c: PWMParams) extends PWMSignals[T](pingen, c)
+
+object PWMPinsFromPort {
+  def apply[T <: Pin] (pins: PWMSignals[T], port: PWMPortIO): Unit = {
+    (pins.pwm zip port.port)  foreach {case (pin, port) =>
+      pin.outputPin(port)
+    }
+  }
+}

--- a/src/main/scala/devices/spi/SPIPins.scala
+++ b/src/main/scala/devices/spi/SPIPins.scala
@@ -16,25 +16,24 @@ class SPISignals[T <: Data] (pingen: ()=> T, c: SPIParamsBase) extends SPIBundle
 
 }
 
-class SPIPins[T <: Pin] (pingen: ()=> T, c: SPIParamsBase) extends SPISignals(pingen, c) {
+class SPIPins[T <: Pin] (pingen: ()=> T, c: SPIParamsBase) extends SPISignals(pingen, c)
 
-  override def cloneType: this.type =
-    this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
-
-  def fromPort(spi: SPIPortIO, clock: Clock, reset: Bool,
+object SPIPinsFromPort {
+  
+  def apply[T <: Pin](pins: SPISignals[T], spi: SPIPortIO, clock: Clock, reset: Bool,
     syncStages: Int = 0, driveStrength: Bool = Bool(false)) {
 
     withClockAndReset(clock, reset) {
-      sck.outputPin(spi.sck, ds = driveStrength)
+      pins.sck.outputPin(spi.sck, ds = driveStrength)
 
-      (dq zip spi.dq).foreach {case (p, s) =>
+      (pins.dq zip spi.dq).foreach {case (p, s) =>
         p.outputPin(s.o, pue = Bool(true), ds = driveStrength)
         p.o.oe := s.oe
         p.o.ie := ~s.oe
         s.i := ShiftRegister(p.i.ival, syncStages)
       }
 
-      (cs zip spi.cs) foreach { case (c, s) =>
+      (pins.cs zip spi.cs) foreach { case (c, s) =>
         c.outputPin(s, ds = driveStrength)
       }
     }

--- a/src/main/scala/devices/spi/SPIPins.scala
+++ b/src/main/scala/devices/spi/SPIPins.scala
@@ -5,11 +5,18 @@ import Chisel._
 import chisel3.experimental.{withClockAndReset}
 import sifive.blocks.devices.pinctrl.{PinCtrl, Pin}
 
-class SPIPins[T <: Pin] (pingen: ()=> T, c: SPIParamsBase) extends SPIBundle(c) {
+class SPISignals[T <: Data] (pingen: ()=> T, c: SPIParamsBase) extends SPIBundle(c) {
 
   val sck = pingen()
   val dq  = Vec(4, pingen())
   val cs  = Vec(c.csWidth, pingen())
+
+  override def cloneType: this.type =
+    this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]
+
+}
+
+class SPIPins[T <: Pin] (pingen: ()=> T, c: SPIParamsBase) extends SPISignals(pingen, c) {
 
   override def cloneType: this.type =
     this.getClass.getConstructors.head.newInstance(pingen, c).asInstanceOf[this.type]

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -4,10 +4,8 @@ package sifive.blocks.devices.uart
 import Chisel._
 import chisel3.experimental.{withClockAndReset}
 import freechips.rocketchip.config.Field
-import freechips.rocketchip.util.SyncResetSynchronizerShiftReg
 import freechips.rocketchip.coreplex.{HasPeripheryBus, PeripheryBusKey, HasInterruptBus}
 import freechips.rocketchip.diplomacy.{LazyModule, LazyMultiIOModuleImp}
-import sifive.blocks.devices.pinctrl.{Pin}
 
 case object PeripheryUARTKey extends Field[Seq[UARTParams]]
 
@@ -39,20 +37,3 @@ trait HasPeripheryUARTModuleImp extends LazyMultiIOModuleImp with HasPeripheryUA
     io <> device.module.io.port
   }
 }
-
-class UARTPins[T <: Pin] (pingen: () => T) extends Bundle {
-  val rxd = pingen()
-  val txd = pingen()
-
-  override def cloneType: this.type =
-    this.getClass.getConstructors.head.newInstance(pingen).asInstanceOf[this.type]
-
-  def fromPort(uart: UARTPortIO, clock: Clock, reset: Bool, syncStages: Int = 0) {
-    withClockAndReset(clock, reset) {
-      txd.outputPin(uart.txd)
-      val rxd_t = rxd.inputPin()
-      uart.rxd := SyncResetSynchronizerShiftReg(rxd_t, syncStages, init = Bool(true), name = Some("uart_rxd_sync"))
-    }
-  }
-}
-

--- a/src/main/scala/devices/uart/UARTPins.scala
+++ b/src/main/scala/devices/uart/UARTPins.scala
@@ -9,7 +9,6 @@ import freechips.rocketchip.coreplex.{HasPeripheryBus, PeripheryBusKey, HasInter
 import freechips.rocketchip.diplomacy.{LazyModule, LazyMultiIOModuleImp}
 import sifive.blocks.devices.pinctrl.{Pin}
 
-
 class UARTSignals[T <: Data] (pingen: () => T) extends Bundle {
   val rxd = pingen()
   val txd = pingen()
@@ -18,14 +17,13 @@ class UARTSignals[T <: Data] (pingen: () => T) extends Bundle {
     this.getClass.getConstructors.head.newInstance(pingen).asInstanceOf[this.type]
 }
 
-class UARTPins[T <: Pin] (pingen: () => T) extends UARTSignals[T](pingen, c) {
-  override def cloneType: this.type =
-    this.getClass.getConstructors.head.newInstance(pingen).asInstanceOf[this.type]
+class UARTPins[T <: Pin] (pingen: () => T) extends UARTSignals[T](pingen)
 
-  def fromPort(uart: UARTPortIO, clock: Clock, reset: Bool, syncStages: Int = 0) {
+object UARTPinsFromPort {
+  def apply[T <: Pin](pins: UARTSignals[T], uart: UARTPortIO, clock: Clock, reset: Bool, syncStages: Int = 0) {
     withClockAndReset(clock, reset) {
-      txd.outputPin(uart.txd)
-      val rxd_t = rxd.inputPin()
+      pins.txd.outputPin(uart.txd)
+      val rxd_t = pins.rxd.inputPin()
       uart.rxd := SyncResetSynchronizerShiftReg(rxd_t, syncStages, init = Bool(true), name = Some("uart_rxd_sync"))
     }
   }

--- a/src/main/scala/devices/uart/UARTPins.scala
+++ b/src/main/scala/devices/uart/UARTPins.scala
@@ -1,0 +1,33 @@
+// See LICENSE for license details.
+package sifive.blocks.devices.uart
+
+import Chisel._
+import chisel3.experimental.{withClockAndReset}
+import freechips.rocketchip.config.Field
+import freechips.rocketchip.util.SyncResetSynchronizerShiftReg
+import freechips.rocketchip.coreplex.{HasPeripheryBus, PeripheryBusKey, HasInterruptBus}
+import freechips.rocketchip.diplomacy.{LazyModule, LazyMultiIOModuleImp}
+import sifive.blocks.devices.pinctrl.{Pin}
+
+
+class UARTSignals[T <: Data] (pingen: () => T) extends Bundle {
+  val rxd = pingen()
+  val txd = pingen()
+
+  override def cloneType: this.type =
+    this.getClass.getConstructors.head.newInstance(pingen).asInstanceOf[this.type]
+}
+
+class UARTPins[T <: Pin] (pingen: () => T) extends UARTSignals[T](pingen, c) {
+  override def cloneType: this.type =
+    this.getClass.getConstructors.head.newInstance(pingen).asInstanceOf[this.type]
+
+  def fromPort(uart: UARTPortIO, clock: Clock, reset: Bool, syncStages: Int = 0) {
+    withClockAndReset(clock, reset) {
+      txd.outputPin(uart.txd)
+      val rxd_t = rxd.inputPin()
+      uart.rxd := SyncResetSynchronizerShiftReg(rxd_t, syncStages, init = Bool(true), name = Some("uart_rxd_sync"))
+    }
+  }
+}
+


### PR DESCRIPTION
In order to make more interesting named bundles similar to Pins, create super class "Signal" bundles of type T. The old XYZPins are now XYZSignals[T <: Pin]. 

All the old `fromPort` methods have to be replaced with objects on the typed bundles to increase their usability.