### PR TITLE
periphery: bus api update

### DIFF
--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -3,16 +3,17 @@ package sifive.blocks.devices.i2c
 
 import Chisel._
 import freechips.rocketchip.config.Field
-import freechips.rocketchip.coreplex.{HasPeripheryBus, HasInterruptBus}
+import freechips.rocketchip.subsystem.BaseSubsystem
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 
 case object PeripheryI2CKey extends Field[Seq[I2CParams]]
 
-trait HasPeripheryI2C extends HasPeripheryBus {
+trait HasPeripheryI2C { this: BaseSubsystem =>
   val i2cParams = p(PeripheryI2CKey)
-  val i2c = i2cParams map { params =>
-    val i2c = LazyModule(new TLI2C(pbus.beatBytes, params))
-    i2c.node := pbus.toVariableWidthSlaves
+  val i2c = i2cParams.zipWithIndex.map { case(params, i) =>
+    val name = Some(s"i2c_$i")
+    val i2c = LazyModule(new TLI2C(pbus.beatBytes, params)).suggestName(name)
+    pbus.toVariableWidthSlave(name) { i2c.node }
     ibus.fromSync := i2c.intnode
     i2c
   }

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -3,7 +3,7 @@ package sifive.blocks.devices.pwm
 
 import Chisel._
 import freechips.rocketchip.config.Field
-import freechips.rocketchip.coreplex.{HasPeripheryBus, HasInterruptBus}
+import freechips.rocketchip.subsystem.BaseSubsystem
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import freechips.rocketchip.util.HeterogeneousBag
 import sifive.blocks.devices.pinctrl.{Pin}
@@ -16,11 +16,12 @@ class PWMPortIO(val c: PWMParams) extends Bundle {
 
 case object PeripheryPWMKey extends Field[Seq[PWMParams]]
 
-trait HasPeripheryPWM extends HasPeripheryBus with HasInterruptBus {
+trait HasPeripheryPWM { this: BaseSubsystem =>
   val pwmParams = p(PeripheryPWMKey)
-  val pwms = pwmParams map { params =>
-    val pwm = LazyModule(new TLPWM(pbus.beatBytes, params))
-    pwm.node := pbus.toVariableWidthSlaves
+  val pwms = pwmParams.zipWithIndex.map { case(params, i) =>
+    val name = Some(s"pwm_$i")
+    val pwm = LazyModule(new TLPWM(pbus.beatBytes, params)).suggestName(name)
+    pbus.toVariableWidthSlave(name) { pwm.node }
     ibus.fromSync := pwm.intnode
     pwm
   }

--- a/src/main/scala/devices/pwm/PWMPins.scala
+++ b/src/main/scala/devices/pwm/PWMPins.scala
@@ -2,10 +2,6 @@
 package sifive.blocks.devices.pwm
 
 import Chisel._
-import freechips.rocketchip.config.Field
-import freechips.rocketchip.coreplex.{HasPeripheryBus, HasInterruptBus}
-import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
-import freechips.rocketchip.util.HeterogeneousBag
 import sifive.blocks.devices.pinctrl.{Pin}
 
 class PWMSignals[T <: Data] (pingen: ()=> T, val c: PWMParams) extends Bundle {

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -3,18 +3,19 @@ package sifive.blocks.devices.spi
 
 import Chisel._
 import freechips.rocketchip.config.Field
-import freechips.rocketchip.coreplex.{HasPeripheryBus, HasInterruptBus}
+import freechips.rocketchip.subsystem.BaseSubsystem
 import freechips.rocketchip.diplomacy.{LazyModule,LazyModuleImp,BufferParams}
 import freechips.rocketchip.tilelink.{TLFragmenter,TLBuffer}
 import freechips.rocketchip.util.HeterogeneousBag
 
 case object PeripherySPIKey extends Field[Seq[SPIParams]]
 
-trait HasPeripherySPI extends HasPeripheryBus with HasInterruptBus {
+trait HasPeripherySPI { this: BaseSubsystem =>
   val spiParams = p(PeripherySPIKey)  
-  val spis = spiParams map { params =>
-    val spi = LazyModule(new TLSPI(pbus.beatBytes, params))
-    spi.rnode := pbus.toVariableWidthSlaves
+  val spis = spiParams.zipWithIndex.map { case(params, i) =>
+    val name = Some(s"spi_$i")
+    val spi = LazyModule(new TLSPI(pbus.beatBytes, params)).suggestName(name)
+    pbus.toVariableWidthSlave(name) { spi.rnode }
     ibus.fromSync := spi.intnode
     spi
   }
@@ -36,15 +37,16 @@ trait HasPeripherySPIModuleImp extends LazyModuleImp with HasPeripherySPIBundle 
 
 case object PeripherySPIFlashKey extends Field[Seq[SPIFlashParams]]
 
-trait HasPeripherySPIFlash extends HasPeripheryBus with HasInterruptBus {
+trait HasPeripherySPIFlash { this: BaseSubsystem =>
   val spiFlashParams = p(PeripherySPIFlashKey)  
-  val qspis = spiFlashParams map { params =>
+  val qspis = spiFlashParams.zipWithIndex.map { case(params, i) =>
+    val name = Some(s"qspi_$i")
     val qspi = LazyModule(new TLSPIFlash(pbus.beatBytes, params))
-    qspi.rnode := pbus.toVariableWidthSlaves
-    (qspi.fnode
-      := TLFragmenter(1, pbus.blockBytes)
-      := TLBuffer(BufferParams(params.fBufferDepth), BufferParams.none)
-      := pbus.toFixedWidthSlaves)
+    pbus.toVariableWidthSlave(name) { qspi.rnode }
+    qspi.fnode := pbus.toFixedWidthSlave(name) {
+      TLFragmenter(1, pbus.blockBytes) :=
+        TLBuffer(BufferParams(params.fBufferDepth), BufferParams.none)
+    }
     ibus.fromSync := qspi.intnode
     qspi
   }

--- a/src/main/scala/devices/uart/UARTPins.scala
+++ b/src/main/scala/devices/uart/UARTPins.scala
@@ -3,10 +3,7 @@ package sifive.blocks.devices.uart
 
 import Chisel._
 import chisel3.experimental.{withClockAndReset}
-import freechips.rocketchip.config.Field
 import freechips.rocketchip.util.SyncResetSynchronizerShiftReg
-import freechips.rocketchip.coreplex.{HasPeripheryBus, PeripheryBusKey, HasInterruptBus}
-import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import sifive.blocks.devices.pinctrl.{Pin}
 
 class UARTSignals[T <: Data] (pingen: () => T) extends Bundle {


### PR DESCRIPTION
Keep up to date with api changes in rocket-chip.

Future work will add per-peripheral clock crossing options.