### PR TITLE
Add descriptions to Timers and friends

### DIFF
--- a/src/main/scala/devices/mockaon/RTC.scala
+++ b/src/main/scala/devices/mockaon/RTC.scala
@@ -3,19 +3,36 @@ package sifive.blocks.devices.mockaon
 
 import Chisel._
 import Chisel.ImplicitConversions._
+import chisel3.experimental.MultiIOModule
 import freechips.rocketchip.util.AsyncResetReg
+import freechips.rocketchip.regmapper.RegFieldDesc
 
-import sifive.blocks.util.{SlaveRegIF, GenericTimer}
+import sifive.blocks.util.{SlaveRegIF, GenericTimer, GenericTimerIO, DefaultGenericTimerCfgDescs}
 
+class RTC extends MultiIOModule with GenericTimer {
 
-class RTC extends GenericTimer {
+  protected def prefix = "rtc"
   protected def countWidth = 48
   protected def cmpWidth = 32
   protected def ncmp = 1
   protected def countEn = countAlways
-  override protected lazy val ip = Reg(next = elapsed(0))
+  override protected lazy val ip = RegNext(elapsed)
   override protected lazy val zerocmp = Bool(false)
-  protected lazy val countAlways = AsyncResetReg(io.regs.cfg.write.countAlwayys, io.regs.cfg.write_countalways && unlocked)(0)
+  protected lazy val countAlways = AsyncResetReg(io.regs.cfg.write.countAlways, io.regs.cfg.write_countAlways && unlocked)(0)
   protected lazy val feed = Bool(false)
-  lazy val io = new GenericTimerIO
+
+  override protected lazy val feed_desc = RegFieldDesc.reserved
+  override protected lazy val key_desc = RegFieldDesc.reserved
+  override protected lazy val cfg_desc = DefaultGenericTimerCfgDescs("rtc", ncmp).copy(
+    sticky = RegFieldDesc.reserved,
+    zerocmp = RegFieldDesc.reserved,
+    deglitch = RegFieldDesc.reserved,
+    running = RegFieldDesc.reserved,
+    center = Seq.fill(ncmp){ RegFieldDesc.reserved },
+    extra = Seq.fill(ncmp){ RegFieldDesc.reserved },
+    gang = Seq.fill(ncmp){ RegFieldDesc.reserved }
+  )
+
+  lazy val io = IO(new GenericTimerIO(regWidth, ncmp, maxcmp, scaleWidth, countWidth, cmpWidth))
+
 }

--- a/src/main/scala/devices/mockaon/RTC.scala
+++ b/src/main/scala/devices/mockaon/RTC.scala
@@ -1,0 +1,21 @@
+// See LICENSE for license details.
+package sifive.blocks.devices.mockaon
+
+import Chisel._
+import Chisel.ImplicitConversions._
+import freechips.rocketchip.util.AsyncResetReg
+
+import sifive.blocks.util.{SlaveRegIF, GenericTimer}
+
+
+class RTC extends GenericTimer {
+  protected def countWidth = 48
+  protected def cmpWidth = 32
+  protected def ncmp = 1
+  protected def countEn = countAlways
+  override protected lazy val ip = Reg(next = elapsed(0))
+  override protected lazy val zerocmp = Bool(false)
+  protected lazy val countAlways = AsyncResetReg(io.regs.cfg.write.countAlwayys, io.regs.cfg.write_countalways && unlocked)(0)
+  protected lazy val feed = Bool(false)
+  lazy val io = new GenericTimerIO
+}

--- a/src/main/scala/devices/mockaon/WatchdogTimer.scala
+++ b/src/main/scala/devices/mockaon/WatchdogTimer.scala
@@ -3,13 +3,16 @@ package sifive.blocks.devices.mockaon
 
 import Chisel._
 import Chisel.ImplicitConversions._
+import chisel3.experimental.MultiIOModule
 import freechips.rocketchip.util.AsyncResetReg
+import freechips.rocketchip.regmapper.{RegFieldDesc}
 
-import sifive.blocks.util.{SlaveRegIF, GenericTimer}
+import sifive.blocks.util.{SlaveRegIF, GenericTimer, GenericTimerIO, GenericTimerCfgRegIFC, DefaultGenericTimerCfgDescs}
 
 object WatchdogTimer {
   def writeAnyExceptKey(regs: Bundle, keyReg: SlaveRegIF): Bool = {
     regs.elements.values.filter(_ ne keyReg).map({
+      case c: GenericTimerCfgRegIFC => c.anyWriteValid
       case v: Vec[SlaveRegIF] @unchecked => v.map(_.write.valid).reduce(_||_)
       case s: SlaveRegIF => s.write.valid
     }).reduce(_||_)
@@ -18,18 +21,19 @@ object WatchdogTimer {
   val key = 0x51F15E
 }
 
-class WatchdogTimer extends GenericTimer {
+class WatchdogTimer extends MultiIOModule with GenericTimer {
+  protected def prefix = "wdog"
   protected def countWidth = 31
   protected def cmpWidth = 16
   protected def ncmp = 1
-  protected lazy val countAlways = AsyncResetReg(io.regs.cfg.write.bits(12), io.regs.cfg.write.valid && unlocked)(0)
-  override protected lazy val countAwake = AsyncResetReg(io.regs.cfg.write.bits(13), io.regs.cfg.write.valid && unlocked)(0)
+  protected lazy val countAlways = AsyncResetReg(io.regs.cfg.write.countAlways, io.regs.cfg.write_countAlways && unlocked)(0)
+  override protected lazy val countAwake = AsyncResetReg(io.regs.cfg.write.running, io.regs.cfg.write_running && unlocked)(0)
   protected lazy val countEn = {
     val corerstSynchronized = Reg(next = Reg(next = io.corerst))
     countAlways || (countAwake && !corerstSynchronized)
   }
-  override protected lazy val rsten = AsyncResetReg(io.regs.cfg.write.bits(8), io.regs.cfg.write.valid && unlocked)(0)
-  protected lazy val ip = RegEnable(io.regs.cfg.write.bits(28) || elapsed(0), (io.regs.cfg.write.valid && unlocked) || elapsed(0))
+  override protected lazy val rsten = AsyncResetReg(io.regs.cfg.write.sticky, io.regs.cfg.write_sticky && unlocked)(0)
+  protected lazy val ip = RegEnable(Vec(Seq(io.regs.cfg.write.ip(0) || elapsed(0))), (io.regs.cfg.write_ip(0) && unlocked) || elapsed(0))
   override protected lazy val unlocked = {
     val writeAny = WatchdogTimer.writeAnyExceptKey(io.regs, io.regs.key)
     AsyncResetReg(io.regs.key.write.bits === WatchdogTimer.key && !writeAny, io.regs.key.write.valid || writeAny)(0)
@@ -38,21 +42,25 @@ class WatchdogTimer extends GenericTimer {
     val food = 0xD09F00D
     unlocked && io.regs.feed.write.valid && io.regs.feed.write.bits === food
   }
-  lazy val io = new GenericTimerIO {
+
+  // The Scala Type-Chekcher seems to have a bug and I get a null pointer during the Scala compilation
+  // if I don't do this temporary assignment.
+  val tmpStickyDesc =  RegFieldDesc("wdogrsten", "Controls whether the comparator output can set the wdogrst bit and hence cause a full reset.",
+      reset = Some(0))
+
+  override protected lazy val cfg_desc = DefaultGenericTimerCfgDescs("wdog", ncmp).copy(
+    sticky = tmpStickyDesc,
+    deglitch = RegFieldDesc.reserved,
+    running = RegFieldDesc("wdogcoreawake", "Increment the watchdog counter if the processor is not asleep", reset=Some(0)),
+    center = Seq.fill(ncmp){RegFieldDesc.reserved},
+    extra = Seq.fill(ncmp){RegFieldDesc.reserved},
+    gang = Seq.fill(ncmp){RegFieldDesc.reserved}
+  )
+
+  lazy val io = IO(new GenericTimerIO(regWidth, ncmp, maxcmp, scaleWidth, countWidth, cmpWidth) {
     val corerst = Bool(INPUT)
     val rst = Bool(OUTPUT)
   }
+  )
   io.rst := AsyncResetReg(Bool(true), rsten && elapsed(0))
-}
-
-class RTC extends GenericTimer {
-  protected def countWidth = 48
-  protected def cmpWidth = 32
-  protected def ncmp = 1
-  protected def countEn = countAlways
-  override protected lazy val ip = Reg(next = elapsed(0))
-  override protected lazy val zerocmp = Bool(false)
-  protected lazy val countAlways = AsyncResetReg(io.regs.cfg.write.bits(12), io.regs.cfg.write.valid && unlocked)(0)
-  protected lazy val feed = Bool(false)
-  lazy val io = new GenericTimerIO
 }

--- a/src/main/scala/devices/pwm/PWM.scala
+++ b/src/main/scala/devices/pwm/PWM.scala
@@ -8,36 +8,50 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
-import sifive.blocks.util.GenericTimer
+import sifive.blocks.util.{GenericTimer, GenericTimerIO, DefaultGenericTimerCfgDescs}
 
 // Core PWM Functionality  & Register Interface
 
-class PWM(val ncmp: Int = 4, val cmpWidth: Int = 16) extends GenericTimer {
+class PWM(val ncmp: Int = 4, val cmpWidth: Int = 16) extends MultiIOModule with GenericTimer {
+
+  def orR(v: Vec[Bool]): Bool = v.foldLeft(Bool(false))( _||_ )
+
+  protected def prefix = "pwm"
   protected def countWidth = ((1 << scaleWidth) - 1) + cmpWidth
-  protected lazy val countAlways = RegEnable(io.regs.cfg.write.bits(12), Bool(false), io.regs.cfg.write.valid && unlocked)
+  protected lazy val countAlways = RegEnable(io.regs.cfg.write.countAlways, Bool(false), io.regs.cfg.write_countAlways && unlocked)
   protected lazy val feed = count.carryOut(scale + UInt(cmpWidth))
   protected lazy val countEn = Wire(Bool())
-  override protected lazy val oneShot = RegEnable(io.regs.cfg.write.bits(13) && !countReset, Bool(false), (io.regs.cfg.write.valid && unlocked) || countReset)
-  override protected lazy val extra  = RegEnable(io.regs.cfg.write.bits(20 + ncmp - 1, 20), init = 0.U, enable = io.regs.cfg.write.valid && unlocked)
-  override protected lazy val center = RegEnable(io.regs.cfg.write.bits(16 + ncmp - 1, 16), io.regs.cfg.write.valid && unlocked)
-  override protected lazy val gang = RegEnable(io.regs.cfg.write.bits(24 + ncmp - 1, 24), io.regs.cfg.write.valid && unlocked)
-  override protected lazy val deglitch = RegEnable(io.regs.cfg.write.bits(10), io.regs.cfg.write.valid && unlocked)(0)
-  override protected lazy val sticky = RegEnable(io.regs.cfg.write.bits(8), io.regs.cfg.write.valid && unlocked)(0)
+  override protected lazy val oneShot = RegEnable(io.regs.cfg.write.running && !countReset, Bool(false), (io.regs.cfg.write_running && unlocked) || countReset)
+  override protected lazy val extra: Vec[Bool]  = RegEnable(io.regs.cfg.write.extra, init = Vec.fill(maxcmp){false.B}, orR(io.regs.cfg.write_extra) && unlocked)
+  override protected lazy val center: Vec[Bool] = RegEnable(io.regs.cfg.write.center, orR(io.regs.cfg.write_center) && unlocked)
+  override protected lazy val gang: Vec[Bool] = RegEnable(io.regs.cfg.write.gang, orR(io.regs.cfg.write_gang) && unlocked)
+  override protected lazy val deglitch = RegEnable(io.regs.cfg.write.deglitch, io.regs.cfg.write_deglitch && unlocked)(0)
+  override protected lazy val sticky = RegEnable(io.regs.cfg.write.sticky, io.regs.cfg.write_sticky && unlocked)(0)
   override protected lazy val ip = {
     val doSticky = Reg(next = (deglitch && !countReset) || sticky)
-    val sel = ((0 until ncmp).map(i => s(cmpWidth-1) && center(i))).asUInt
-    val reg = Reg(UInt(width = ncmp))
-    reg := (sel & elapsed.asUInt) | (~sel & (elapsed.asUInt | (Fill(ncmp, doSticky) & reg)))
-    when (io.regs.cfg.write.valid && unlocked) { reg := io.regs.cfg.write.bits(28 + ncmp - 1, 28) }
+    val sel = (0 until ncmp).map(i => s(cmpWidth-1) && center(i))
+    val reg = Reg(Vec(ncmp, Bool()))
+    reg := (sel & elapsed) | (~sel & (elapsed | (Vec.fill(ncmp){doSticky} & reg)))
+    when (orR(io.regs.cfg.write_ip) && unlocked) { reg := io.regs.cfg.write_ip }
     reg
   }
-  lazy val io = new GenericTimerIO {
+
+  override protected lazy val feed_desc = RegFieldDesc.reserved
+  override protected lazy val key_desc = RegFieldDesc.reserved
+  override protected lazy val cfg_desc = DefaultGenericTimerCfgDescs("pwm", ncmp).copy(
+    extra = Seq.tabulate(ncmp){ i => RegFieldDesc(s"pwminvert${i}", s"Invert Comparator ${i} Output", reset = Some(0))}
+  )
+
+  lazy val io = IO(new GenericTimerIO(regWidth, ncmp, maxcmp, scaleWidth, countWidth, cmpWidth) {
     val gpio = Vec(ncmp, Bool()).asOutput
-  }
+  })
 
-  val invert = extra
+  val invert = extra.asUInt
 
-  io.gpio := io.gpio.fromBits((ip & ~(gang & Cat(ip(0), ip >> 1))) ^ invert)
+  val ipU = ip.asUInt
+  val gangU = gang.asUInt
+
+  io.gpio := io.gpio.fromBits((ipU & ~(gangU & Cat(ipU(0), ipU >> 1))) ^ invert)
   countEn := countAlways || oneShot
 }
 

--- a/src/main/scala/util/SlaveRegIF.scala
+++ b/src/main/scala/util/SlaveRegIF.scala
@@ -4,11 +4,11 @@ package sifive.blocks.util
 import Chisel._
 import freechips.rocketchip.regmapper._
 
-class SlaveRegIF(private val w: Int, private val desc: Option[RegFieldDesc]) extends Bundle {
+class SlaveRegIF(private val w: Int) extends Bundle {
   val write = Valid(UInt(width = w)).flip
   val read = UInt(OUTPUT, w)
 
-  def toRegField(dummy: Int = 0): RegField = {
+  def toRegField(desc: Option[RegFieldDesc] = None): RegField = {
     def writeFn(valid: Bool, data: UInt): Bool = {
       write.valid := valid
       write.bits := data

--- a/src/main/scala/util/SlaveRegIF.scala
+++ b/src/main/scala/util/SlaveRegIF.scala
@@ -1,0 +1,19 @@
+// See LICENSE for license details.
+package sifive.blocks.util
+
+import Chisel._
+import freechips.rocketchip.regmapper._
+
+class SlaveRegIF(private val w: Int, private val desc: Option[RegFieldDesc]) extends Bundle {
+  val write = Valid(UInt(width = w)).flip
+  val read = UInt(OUTPUT, w)
+
+  def toRegField(dummy: Int = 0): RegField = {
+    def writeFn(valid: Bool, data: UInt): Bool = {
+      write.valid := valid
+      write.bits := data
+      Bool(true)
+    }
+    RegField(w, RegReadFn(read), RegWriteFn((v, d) => writeFn(v, d)), desc)
+  }
+}

--- a/src/main/scala/util/Timer.scala
+++ b/src/main/scala/util/Timer.scala
@@ -6,60 +6,200 @@ import Chisel.ImplicitConversions._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.util.WideCounter
 
-class SlaveRegIF(private val w: Int) extends Bundle {
-  val write = Valid(UInt(width = w)).flip
-  val read = UInt(OUTPUT, w)
+import scala.math.{min, max}
 
-  def toRegField(dummy: Int = 0): RegField = {
-    def writeFn(valid: Bool, data: UInt): Bool = {
-      write.valid := valid
-      write.bits := data
+class GenericTimerCfgReg(
+  val maxcmp: Int,
+  val scaleWidth: Int) extends Bundle {
+
+  val ip = Vec(maxcmp, Bool())
+  val gang = Vec(maxcmp, Bool())
+  val extra = Vec(maxcmp, Bool())
+  val center = Vec(maxcmp, Bool())
+  val reserved0 = UInt(width = 2)
+  val running = Bool()
+  val countAlways = Bool()
+  val reserved1 = UInt(width = 1)
+  val deglitch = Bool()
+  val zerocmp = Bool()
+  val sticky = Bool()
+  val reserved2 = UInt(width = 8 - scaleWidth)
+  val scale = UInt(width = scaleWidth)
+
+}
+
+case class GenericTimerCfgDescs(
+  scale: RegFieldDesc,
+  sticky: RegFieldDesc,
+  zerocmp: RegFieldDesc,
+  deglitch:RegFieldDesc,
+  countAlways: RegFieldDesc,
+  running: RegFieldDesc,
+  center: Seq[RegFieldDesc],
+  extra: Seq[RegFieldDesc],
+  gang: Seq[RegFieldDesc],
+  ip: Seq[RegFieldDesc]
+)
+
+object DefaultGenericTimerCfgDescs  {
+  def apply(prefix: String, ncmp: Int): GenericTimerCfgDescs = GenericTimerCfgDescs(
+    scale = RegFieldDesc(s"${prefix}scale", "Counter scale value."),
+    sticky = RegFieldDesc(s"${prefix}sticky", "Sticky. Disallow clearing of ${prefix}cmpXip bits"),
+    zerocmp = RegFieldDesc(s"${prefix}zerocmp", "Reset counter to zero after match."),
+    deglitch =  RegFieldDesc(s"${prefix}deglitch", "Deglitch - latch ${prefix}cmpXip within same cycle."),
+    countAlways = RegFieldDesc(s"${prefix}enalways", "Enable Always - run continuously",
+      reset = Some(0)),
+    running = RegFieldDesc(s"${prefix}oneshot", "Enable One Shot - run one cycle, then this bit is cleared.",
+      reset=Some(0), volatile=true),
+    center = Seq.tabulate(ncmp){ i => RegFieldDesc(s"${prefix}cmp${i}center", s"Comparator ${i} Center")},
+    extra = Seq.tabulate(ncmp){ i => RegFieldDesc(s"${prefix}extra${i}", s"Comparator ${i} Extra")},
+    gang = Seq.tabulate(ncmp){ i => RegFieldDesc(s"${prefix}gang${i}", s"Comparator ${i}/${(i+1) % ncmp} Gang")},
+    ip = Seq.tabulate(ncmp){ i => RegFieldDesc(s"${prefix}ip${i}", s"Interrupt ${i} Pending")}
+  )
+}
+
+class GenericTimerCfgRegIFC (
+  val ncmp: Int,
+  val maxcmp: Int,
+  val scaleWidth: Int) extends Bundle {
+
+  val write = new GenericTimerCfgReg(maxcmp, scaleWidth).asInput
+  val read =  new GenericTimerCfgReg(maxcmp, scaleWidth).asOutput
+
+  val write_ip = Vec(maxcmp, Bool(INPUT))
+  val write_gang = Vec(maxcmp, Bool(INPUT))
+  val write_extra = Vec(maxcmp, Bool(INPUT))
+  val write_center = Vec(maxcmp, Bool(INPUT))
+  val write_running = Bool(INPUT)
+  val write_countAlways = Bool(INPUT)
+  val write_deglitch = Bool(INPUT)
+  val write_zerocmp = Bool(INPUT)
+  val write_sticky = Bool(INPUT)
+  val write_scale = Bool(INPUT)
+
+  def toRegFields(prefix: String, descs: GenericTimerCfgDescs): Seq[RegField] = {
+
+    def writeFn(valid: Bool, data: UInt, wr_data: UInt, wr_notify: Bool): Bool = {
+      wr_notify := valid
+      wr_data   := data
       Bool(true)
     }
-    RegField(w, RegReadFn(read), RegWriteFn((v, d) => writeFn(v, d)))
+
+    // Defaults, because only ncmp of these are assigned by the regmap below.
+    val write_ip = Vec.fill(maxcmp){false.B}
+    val write_gang = Vec.fill(maxcmp){false.B}
+    val write_extra = Vec.fill(maxcmp){false.B}
+    val write_center = Vec.fill(maxcmp){false.B}
+
+    RegFieldGroup(s"${prefix}cfg", Some("${prefix} Configuration"),
+      Seq(
+        RegField(scaleWidth, RegReadFn(read.scale), RegWriteFn((v, d) => writeFn(v, d, write.scale, write_scale)), descs.scale),
+        RegField(8-scaleWidth),
+        RegField(1, RegReadFn(read.sticky), RegWriteFn((v, d) => writeFn(v, d, write.sticky, write_sticky)), descs.sticky),
+        RegField(1, RegReadFn(read.zerocmp), RegWriteFn((v, d) => writeFn(v, d, write.zerocmp, write_zerocmp)), descs.zerocmp),
+        RegField(1, RegReadFn(read.deglitch), RegWriteFn((v, d) => writeFn(v, d, write.deglitch, write_deglitch)), descs.deglitch),
+        RegField(1),
+        RegField(1, RegReadFn(read.countAlways), RegWriteFn((v, d) => writeFn(v, d, write.countAlways, write_countAlways)), descs.countAlways),
+        RegField(1, RegReadFn(read.running), RegWriteFn((v, d) => writeFn(v, d, write.running, write_running)), descs.running),
+        RegField(2)
+      ) ++ Seq.tabulate(ncmp) { i =>
+        RegField(1, RegReadFn(read.center(i)), RegWriteFn((v, d) => writeFn(v, d, write.center(i), write_center(i))), descs.center(i))
+      }
+      ++ (if (ncmp < maxcmp) Seq(RegField(maxcmp - ncmp)) else Nil)
+      ++ Seq.tabulate(ncmp) { i =>
+          RegField(1, RegReadFn(read.extra(i)),
+          RegWriteFn((v, d) => writeFn(v, d, write.extra(i), write_extra(i))), descs.extra(i))
+      }
+      ++ (if (ncmp < maxcmp) Seq(RegField(maxcmp - ncmp)) else Nil)
+      ++ Seq.tabulate(ncmp) { i =>
+        RegField(1, RegReadFn(read.gang(i)),
+          RegWriteFn((v, d) => writeFn(v, d, write.gang(i), write_gang(i))), descs.gang(i))
+      }
+      ++ (if (ncmp < maxcmp) Seq(RegField(maxcmp - ncmp)) else Nil)
+      ++ Seq.tabulate(ncmp) { i =>
+        RegField(1, RegReadFn(read.ip(i)),
+          RegWriteFn((v, d) => writeFn(v, d, write.ip(i), write_ip(i))), descs.ip(i))
+      }
+      ++ (if (ncmp < maxcmp) Seq(RegField(maxcmp - ncmp)) else Nil)
+    )
   }
+
+  def anyWriteValid: Bool = (
+    write_ip ++
+      write_gang ++
+      write_extra ++
+      write_center ++
+      Seq(write_running) ++
+      Seq(write_countAlways) ++
+      Seq(write_deglitch) ++
+      Seq(write_zerocmp) ++
+      Seq(write_sticky) ++
+      Seq(write_scale)
+  ).reduce(_||_)
+
+}
+
+class GenericTimerIO(
+  val regWidth: Int,
+  val ncmp: Int,
+  val maxcmp: Int,
+  val scaleWidth: Int,
+  val countWidth: Int,
+  val cmpWidth: Int) extends Bundle {
+  val regs = new Bundle {
+    val cfg = new GenericTimerCfgRegIFC(ncmp, maxcmp, scaleWidth)
+    val countLo = new SlaveRegIF(min(regWidth, countWidth))
+    // If countWidth < regWidth, countHi ends up as a regWidth wide reserved field.
+    val countHi = new SlaveRegIF(max(regWidth, countWidth - regWidth))
+    val s = new SlaveRegIF(cmpWidth)
+    val cmp = Vec(ncmp, new SlaveRegIF(cmpWidth))
+    val feed = new SlaveRegIF(regWidth)
+    val key = new SlaveRegIF(regWidth)
+  }
+  val ip = Vec(ncmp, Bool()).asOutput
 }
 
 
-abstract class GenericTimer extends Module {
+trait GenericTimer {
+  protected def prefix: String
   protected def countWidth: Int
   protected def cmpWidth: Int
   protected def ncmp: Int
   protected def countAlways: Bool
   protected def countEn: Bool
   protected def feed: Bool
-  protected def ip: UInt
+  protected def ip: Vec[Bool]
   protected def countAwake: Bool = Bool(false)
   protected def unlocked: Bool = Bool(true)
   protected def rsten: Bool = Bool(false)
   protected def deglitch: Bool = Bool(false)
   protected def sticky: Bool = Bool(false)
   protected def oneShot: Bool = Bool(false)
-  protected def center: UInt = UInt(0)
-  protected def extra: UInt = UInt(0)
-  protected def gang: UInt = UInt(0)
+  protected def center: Vec[Bool] = Vec.fill(ncmp){Bool(false)}
+  protected def extra: Vec[Bool] = Vec.fill(ncmp){Bool(false)}
+  protected def gang: Vec[Bool] = Vec.fill(ncmp){Bool(false)}
   protected val scaleWidth = 4
   protected val regWidth = 32
   val maxcmp = 4
   require(ncmp <= maxcmp)
+  require(ncmp > 0)
 
-  class GenericTimerIO extends Bundle {
-    val regs = new Bundle {
-      val cfg = new SlaveRegIF(regWidth)
-      val countLo = new SlaveRegIF(regWidth)
-      val countHi = new SlaveRegIF(regWidth)
-      val s = new SlaveRegIF(cmpWidth)
-      val cmp = Vec(ncmp, new SlaveRegIF(cmpWidth))
-      val feed = new SlaveRegIF(regWidth)
-      val key = new SlaveRegIF(regWidth)
-    }
-    val ip = Vec(ncmp, Bool()).asOutput
+  protected def countLo_desc: RegFieldDesc = if (countWidth > regWidth) {
+    RegFieldDesc(s"${prefix}countLo", "Low bits of Counter", volatile=true)
+  } else  {
+    RegFieldDesc(s"${prefix}count", "Counter Register", volatile=true)
   }
+  protected def countHi_desc: RegFieldDesc = if (countWidth > regWidth) RegFieldDesc(s"${prefix}countHi", "High bits of Counter", volatile=true) else RegFieldDesc.reserved
+  protected def s_desc: RegFieldDesc = RegFieldDesc(s"${prefix}s", "Scaled value of Counter", access=RegFieldAccessType.R, volatile=true)
+  protected def cmp_desc: Seq[RegFieldDesc] = Seq.tabulate(ncmp){ i => RegFieldDesc(s"${prefix}cmp${i}", s"Comparator ${i}")}
+  protected def feed_desc: RegFieldDesc = RegFieldDesc(s"${prefix}feed", "Feed register")
+  protected def key_desc: RegFieldDesc  = RegFieldDesc(s"${prefix}key", "Key Register")
+  protected def cfg_desc: GenericTimerCfgDescs = DefaultGenericTimerCfgDescs(prefix, ncmp)
 
-  def io: GenericTimerIO
+  val io: GenericTimerIO
 
-  protected val scale = RegEnable(io.regs.cfg.write.bits(scaleWidth-1, 0), io.regs.cfg.write.valid && unlocked)
-  protected lazy val zerocmp = RegEnable(io.regs.cfg.write.bits(9), io.regs.cfg.write.valid && unlocked)
+  protected val scale = RegEnable(io.regs.cfg.write.scale, io.regs.cfg.write_scale && unlocked)
+  protected lazy val zerocmp = RegEnable(io.regs.cfg.write.zerocmp, io.regs.cfg.write_zerocmp && unlocked)
   protected val cmp = io.regs.cmp.map(c => RegEnable(c.write.bits, c.write.valid && unlocked))
 
   protected val count = WideCounter(countWidth, countEn, reset = false)
@@ -69,36 +209,43 @@ abstract class GenericTimer extends Module {
   // generate periodic interrupt
   protected val s = (count >> scale)(cmpWidth-1, 0)
   // reset counter when fed or elapsed
-  protected val elapsed =
-    for (i <- 0 until ncmp)
-      yield Mux(s(cmpWidth-1) && center(i), ~s, s) >= cmp(i)
+  protected val elapsed = Vec.tabulate(ncmp){i => Mux(s(cmpWidth-1) && center(i), ~s, s) >= cmp(i)}
   protected val countReset = feed || (zerocmp && elapsed(0))
   when (countReset) { count := 0 }
 
-  io.regs.cfg.read := Cat(ip, gang | UInt(0, maxcmp), extra | UInt(0, maxcmp), center | UInt(0, maxcmp),
-    UInt(0, 2), countAwake || oneShot, countAlways, UInt(0, 1), deglitch, zerocmp, rsten || sticky,
-    UInt(0, 8-scaleWidth),  scale)
+  io.regs.cfg.read := new GenericTimerCfgReg(maxcmp, scaleWidth).fromBits(0.U)
+  io.regs.cfg.read.ip := ip
+  io.regs.cfg.read.gang := gang
+  io.regs.cfg.read.extra := extra
+  io.regs.cfg.read.center := center
+  io.regs.cfg.read.running := countAwake || oneShot
+  io.regs.cfg.read.countAlways := countAlways
+  io.regs.cfg.read.deglitch := deglitch
+  io.regs.cfg.read.deglitch := zerocmp
+  io.regs.cfg.read.sticky := rsten || sticky
+  io.regs.cfg.read.scale := scale
+
   io.regs.countLo.read := count
   io.regs.countHi.read := count >> regWidth
   io.regs.s.read := s
   (io.regs.cmp zip cmp) map { case (r, c) => r.read := c }
   io.regs.feed.read := 0
   io.regs.key.read := unlocked
-  io.ip := io.ip.fromBits(ip)
+  io.ip := ip
 }
-
 
 object GenericTimer {
   def timerRegMap(t: GenericTimer, offset: Int, regBytes: Int): Seq[(Int, Seq[RegField])] = {
+    val cfgRegs = Seq(offset -> t.io.regs.cfg.toRegFields(t.prefix, t.cfg_desc))
     val regs = Seq(
-      0 -> t.io.regs.cfg,
-      2 -> t.io.regs.countLo,
-      3 -> t.io.regs.countHi,
-      4 -> t.io.regs.s,
-      6 -> t.io.regs.feed,
-      7 -> t.io.regs.key)
-    val cmpRegs = t.io.regs.cmp.zipWithIndex map { case (r, i) => (8 + i) -> r }
-    for ((i, r) <- (regs ++ cmpRegs))
-      yield (offset + regBytes*i) -> Seq(r.toRegField())
+        2 -> (t.io.regs.countLo, t.countLo_desc),
+        3 -> (t.io.regs.countHi, t.countHi_desc),
+        4 -> (t.io.regs.s, t.s_desc),
+        6 -> (t.io.regs.feed, t.feed_desc),
+        7 -> (t.io.regs.key, t.key_desc)
+    )
+    val cmpRegs = (t.io.regs.cmp zip t.cmp_desc).zipWithIndex map { case ((r, d), i) => (8 + i) -> (r, d) }
+    val otherRegs = for ((i, (r, d)) <- (regs ++ cmpRegs)) yield (offset + regBytes*i) -> Seq(r.toRegField(Some(d)))
+    cfgRegs ++ otherRegs
   }
 }


### PR DESCRIPTION
I wanted to add descriptions to the timer subclasses, which required changing the way they are coded somewhat in order to be able to accurately describe the subfields. I don't *think* I changed any functionality when accessing them as 32 bit registers, but it does now allow you to say, clear the IP bit with a `sb` operation.