### PR TITLE
Allow UART baudrate to be configured

### DIFF
--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -29,7 +29,9 @@ case class UARTParams(
   nRxEntries: Int = 8,
   includeFourWire: Boolean = false,
   includeParity: Boolean = false,
-  includeIndependentParity: Boolean = false) extends DeviceParams // Tx and Rx have opposite parity modes
+  includeIndependentParity: Boolean = false, // Tx and Rx have opposite parity modes
+  initBaudRate: BigInt = BigInt(115200),
+) extends DeviceParams
 {
   def oversampleFactor = 1 << oversample
   require(divisorBits > oversample)
@@ -233,7 +235,7 @@ case class UARTAttachParams(
   def attachTo(where: Attachable)(implicit p: Parameters): TLUART = where {
     val name = s"uart_${UART.nextId()}"
     val tlbus = where.locateTLBusWrapper(controlWhere)
-    val divinit = (tlbus.dtsFrequency.get / 115200).toInt
+    val divinit = (tlbus.dtsFrequency.get / device.initBaudRate).toInt
     val uartClockDomainWrapper = LazyModule(new ClockSinkDomain(take = None))
     val uart = uartClockDomainWrapper { LazyModule(new TLUART(tlbus.beatBytes, device, divinit)) }
     uart.suggestName(name)

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -9,7 +9,6 @@ case object PeripheryUARTKey extends Field[Seq[UARTParams]](Nil)
 
 trait HasPeripheryUART { this: BaseSubsystem =>
   val uartNodes = p(PeripheryUARTKey).map { ps =>
-    val divinit = (p(PeripheryBusKey).dtsFrequency.get / 115200).toInt
     UARTAttachParams(ps).attachTo(this).ioNode.makeSink()
   }
 }


### PR DESCRIPTION
In FireSim, we want the nominal PeripheryBus frequency to be 3.2 GHz. But this makes printing through the UART really slow, since the baud rate is hard-coded to 115200. This commit makes the baud rate configurable.