### PR TITLE
[FU-908] Drive peripherals with newly added pclk

### DIFF
--- a/src/main/scala/devices/chiplink/ChipLink.scala
+++ b/src/main/scala/devices/chiplink/ChipLink.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.devices.tilelink.TLBusBypass
 import freechips.rocketchip.util._
 
-class ChipLink(val params: ChipLinkParams)(implicit p: Parameters) extends LazyModule() {
+class ChipLink(val params: ChipLinkParams)(implicit p: Parameters) extends LazyModule() with LazyScope{
 
   val device = new SimpleBus("chiplink", Seq("sifive,chiplink"))
 

--- a/src/main/scala/devices/gpio/GPIOPeriphery.scala
+++ b/src/main/scala/devices/gpio/GPIOPeriphery.scala
@@ -15,7 +15,7 @@ trait HasPeripheryGPIO { this: BaseSubsystem =>
     val name = Some(s"gpio_$i")
     val gpio = LazyModule(new TLGPIO(pbus.beatBytes, params)).suggestName(name)
     pbus.toVariableWidthSlave(name) { gpio.node }
-    ibus.fromSync := gpio.intnode
+    ibus.fromAsync := gpio.intnode
     gpio
   }
 }

--- a/src/main/scala/devices/gpio/GPIOPins.scala
+++ b/src/main/scala/devices/gpio/GPIOPins.scala
@@ -2,6 +2,7 @@
 package sifive.blocks.devices.gpio
 
 import Chisel._
+import chisel3.experimental.{withClockAndReset}
 import sifive.blocks.devices.pinctrl.{Pin}
 
 // While this is a bit pendantic, it keeps the GPIO
@@ -16,6 +17,17 @@ class GPIOSignals[T <: Data](private val pingen: () => T, private val c: GPIOPar
 class GPIOPins[T <: Pin](pingen: () => T, c: GPIOParams) extends GPIOSignals[T](pingen, c)
 
 object GPIOPinsFromPort {
+
+  def apply[T <: Pin](pins: GPIOSignals[T], port: GPIOPortIO, clock: Clock, reset: Bool){
+
+    // This will just match up the components of the Bundle that
+    // exist in both.
+    withClockAndReset(clock, reset) {
+      (pins.pins zip port.pins) foreach {case (pin, port) =>
+        pin <> port
+      }
+    }
+  }
 
   def apply[T <: Pin](pins: GPIOSignals[T], port: GPIOPortIO){
 

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -21,7 +21,7 @@ trait HasPeripheryPWM { this: BaseSubsystem =>
     val name = Some(s"pwm_$i")
     val pwm = LazyModule(new TLPWM(pbus.beatBytes, params)).suggestName(name)
     pbus.toVariableWidthSlave(name) { pwm.node }
-    ibus.fromSync := pwm.intnode
+    ibus.fromAsync := pwm.intnode
     pwm
   }
 }

--- a/src/main/scala/devices/pwm/PWMPins.scala
+++ b/src/main/scala/devices/pwm/PWMPins.scala
@@ -2,6 +2,7 @@
 package sifive.blocks.devices.pwm
 
 import Chisel._
+import chisel3.experimental.{withClockAndReset}
 import sifive.blocks.devices.pinctrl.{Pin}
 
 class PWMSignals[T <: Data](private val pingen: () => T, val c: PWMParams) extends Bundle {
@@ -11,8 +12,16 @@ class PWMSignals[T <: Data](private val pingen: () => T, val c: PWMParams) exten
 class PWMPins[T <: Pin](pingen: () => T, c: PWMParams) extends PWMSignals[T](pingen, c)
 
 object PWMPinsFromPort {
+  def apply[T <: Pin] (pins: PWMSignals[T], port: PWMPortIO, clock: Clock, reset: Bool): Unit = {
+    withClockAndReset(clock, reset){
+      (pins.pwm zip port.port) foreach { case (pin, port) =>
+        pin.outputPin(port)
+      }
+    }
+  }
+
   def apply[T <: Pin] (pins: PWMSignals[T], port: PWMPortIO): Unit = {
-    (pins.pwm zip port.port)  foreach {case (pin, port) =>
+    (pins.pwm zip port.port) foreach { case (pin, port) =>
       pin.outputPin(port)
     }
   }


### PR DESCRIPTION
Change peripherals with pclk (tl_clk / 4), since tl_clk runs at 0-750MHz, too fast for more peripherals