### PR TITLE
chiplink: support 'denied' in D-channel

### DIFF
--- a/src/main/scala/devices/chiplink/ChipLink.scala
+++ b/src/main/scala/devices/chiplink/ChipLink.scala
@@ -28,6 +28,8 @@ class ChipLink(val params: ChipLinkParams)(implicit p: Parameters) extends LazyM
         supportsPutFull    = params.fullXfer,
         supportsPutPartial = params.fullXfer,
         supportsHint       = params.fullXfer,
+        mayDenyPut         = true,
+        mayDenyGet         = true,
         fifoId             = Some(0))) ++
       maybeManager(params.TLC, a => TLManagerParameters(
         address            = a,
@@ -42,6 +44,8 @@ class ChipLink(val params: ChipLinkParams)(implicit p: Parameters) extends LazyM
         supportsPutFull    = params.fullXfer,
         supportsPutPartial = params.fullXfer,
         supportsHint       = params.fullXfer,
+        mayDenyPut         = true,
+        mayDenyGet         = true,
         fifoId             = Some(0))),
     beatBytes  = 4,
     endSinkId  = params.sinks,

--- a/src/main/scala/devices/chiplink/SinkD.scala
+++ b/src/main/scala/devices/chiplink/SinkD.scala
@@ -46,7 +46,7 @@ class SinkD(info: ChipLinkInfo) extends Module
   val header = info.encode(
     format = UInt(3),
     opcode = d.bits.opcode,
-    param  = d.bits.param,
+    param  = Cat(d.bits.denied, d.bits.param),
     size   = d.bits.size,
     domain = d.bits.source >> log2Ceil(info.params.sourcesPerDomain),
     source = Mux(relack, io.c_clSource, io.a_clSource))

--- a/src/main/scala/devices/chiplink/SourceD.scala
+++ b/src/main/scala/devices/chiplink/SourceD.scala
@@ -63,13 +63,13 @@ class SourceD(info: ChipLinkInfo) extends Module
   val xmit  = q_last || state === s_data
 
   io.d.bits.opcode  := q_opcode
-  io.d.bits.param   := q_param
+  io.d.bits.param   := q_param(1,0)
   io.d.bits.size    := q_size
   io.d.bits.source  := Vec(muxes.map { m => m(q_source) })(q_domain)
   io.d.bits.sink    := Mux(q_grant, sink, UInt(0))
-  io.d.bits.denied  := Bool(false)
+  io.d.bits.denied  := q_param >> 2
   io.d.bits.data    := io.q.bits
-  io.d.bits.corrupt := Bool(false)
+  io.d.bits.corrupt := io.d.bits.denied && info.edgeIn.hasData(io.d.bits)
 
   io.d.valid := (io.q.valid && !stall) &&  xmit
   io.q.ready := (io.d.ready && !stall) || !xmit


### PR DESCRIPTION
Fortunately, D-channel only uses 2 bits out of the param field.
Therefore, it is backwards compatible to re-purpose this bit.

Existing hardware will ignore it, truncating the param field.
Existing hardware will never generate it, filling it with zero.