### PR TITLE
Chiplink registered reset

### DIFF
--- a/src/main/scala/devices/chiplink/ChipLink.scala
+++ b/src/main/scala/devices/chiplink/ChipLink.scala
@@ -2,6 +2,7 @@
 package sifive.blocks.devices.chiplink
 
 import Chisel._
+import chisel3.experimental.withClock
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
@@ -149,7 +150,8 @@ class ChipLink(val params: ChipLinkParams)(implicit p: Parameters) extends LazyM
 
     val rx = Module(new RX(info))
     rx.clock := io.port.b2c.clk
-    rx.reset := io.port.b2c.rst
+    rx.reset := AsyncResetReg(io.port.b2c.rst, io.port.b2c.clk, reset, true, None)
+    // ^^^ Clock recovery is safe, because b2c.rst is high longer than reset
     rx.io.b2c_data := io.port.b2c.data
     rx.io.b2c_send := io.port.b2c.send
     out.a <> sourceA.io.a

--- a/src/main/scala/devices/chiplink/ChipLink.scala
+++ b/src/main/scala/devices/chiplink/ChipLink.scala
@@ -166,8 +166,8 @@ class ChipLink(val params: ChipLinkParams)(implicit p: Parameters) extends LazyM
     sourceE.io.q <> FromAsyncBundle(rx.io.e)
 
     val tx = Module(new TX(info))
-    io.port.c2b.clk := tx.clock
-    io.port.c2b.rst := tx.reset
+    io.port.c2b.clk := tx.io.c2b_clk
+    io.port.c2b.rst := tx.io.c2b_rst
     io.port.c2b.data := tx.io.c2b_data
     io.port.c2b.send := tx.io.c2b_send
     sinkA.io.a <> in .a

--- a/src/main/scala/devices/chiplink/RX.scala
+++ b/src/main/scala/devices/chiplink/RX.scala
@@ -21,7 +21,8 @@ class RX(info: ChipLinkInfo) extends Module
 
   // Immediately register our input data
   val b2c_data = RegNext(RegNext(io.b2c_data))
-  val b2c_send = RegNext(RegNext(io.b2c_send, Bool(false)), Bool(false))
+  val b2c_send = RegNext(RegNext(io.b2c_send), Bool(false))
+  // b2c_send is NOT cleared on the first RegNext because this module's reset has a flop on it
 
   // Fit b2c into the firstlast API
   val beat = Wire(Decoupled(UInt(width = info.params.dataBits)))

--- a/src/main/scala/devices/chiplink/TX.scala
+++ b/src/main/scala/devices/chiplink/TX.scala
@@ -8,6 +8,8 @@ import freechips.rocketchip.util._
 class TX(info: ChipLinkInfo) extends Module
 {
   val io = new Bundle {
+    val c2b_clk  = Clock(OUTPUT)
+    val c2b_rst  = Bool(OUTPUT)
     val c2b_send = Bool(OUTPUT)
     val c2b_data = UInt(OUTPUT, info.params.dataBits)
     val a = new AsyncBundle(info.params.crossingDepth, new DataLayer(info.params)).flip
@@ -90,6 +92,8 @@ class TX(info: ChipLinkInfo) extends Module
   first := (grant & lasts).orR
 
   // Form the output beat
+  io.c2b_clk  := clock
+  io.c2b_rst  := AsyncResetReg(Bool(false), clock, reset, true, None)
   io.c2b_send := RegNext(RegNext(first || (state & valid) =/= UInt(0), Bool(false)), Bool(false))
   io.c2b_data := RegNext(Mux1H(RegNext(grant), RegNext(Vec(ioF.map(_.bits.data)))))
 


### PR DESCRIPTION
This PR puts a register on both the RX and TX chiplink reset pins.
This helps us to close timing when the frequency is increased to 200MHZ.