### PR TITLE
UART: use an alias, not a reference

### DIFF
--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -274,6 +274,6 @@ class TLUART(w: Int, c: UARTParams)(implicit p: Parameters)
 {
   val crossing = c.crossingType
   ResourceBinding {
-    Resource(ResourceAnchors.aliases, "uart").bind(ResourceReference(device.label))
+    Resource(ResourceAnchors.aliases, "uart").bind(ResourceAlias(device.label))
   }
 }


### PR DESCRIPTION
Otherwise, linux will not use the console correctly.