### PR TITLE
chiplink: make RX reset strategy configurable

### DIFF
--- a/src/main/scala/devices/chiplink/Parameters.scala
+++ b/src/main/scala/devices/chiplink/Parameters.scala
@@ -6,7 +6,7 @@ import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 
-case class ChipLinkParams(TLUH: Seq[AddressSet], TLC: Seq[AddressSet], sourceBits: Int = 6, sinkBits: Int = 5, syncTX: Boolean = false)
+case class ChipLinkParams(TLUH: Seq[AddressSet], TLC: Seq[AddressSet], sourceBits: Int = 6, sinkBits: Int = 5, syncTX: Boolean = false, fpgaReset: Option[Clock => Bool] = None)
 {
   val domains = 8 // hard-wired into chiplink protocol
   require (sourceBits >= log2Ceil(domains))


### PR DESCRIPTION
Unfortunately, the RX reset cannot be flopped the same way on both
FPGA and ASIC targets. We require the internal reset high even in the
absence of a valid RX clock. To achieve this, we need an asynchronous
reset register. On an ASIC, the obvious approach is to use the off-chip
reset as an asynchronous set that is analyzed by clock recovery.

However, on an FPGA, for performance, it is necessary to register the
off-chip signal into a register located in the IO buffer. Unfortunately,
these buffers can only take off-chip signals to D, never async set.
On an FPGA, though, it is possible to generate a reset that is high
on power-on.