### PR TITLE
Refactor some peripheral devices to use RegisterRouterIO

### DIFF
--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -223,4 +223,17 @@ object GPIO {
 
     gpio
   }
+
+  def loopback(g: GPIOPortIO)(pinA: Int, pinB: Int) {
+    g.pins.foreach {p =>
+      p.i.ival := Mux(p.o.oe, p.o.oval, p.o.pue) & p.o.ie
+    }
+    val a = g.pins(pinA)
+    val b = g.pins(pinB)
+    // This logic is not QUITE right, it doesn't handle all the subtle cases.
+    // It is probably simpler to just hook a pad up here and use attach()
+    // to model this properly.
+    a.i.ival := Mux(b.o.oe, (b.o.oval | b.o.pue), (a.o.pue | (a.o.oe & a.o.oval))) & a.o.ie
+    b.i.ival := Mux(a.o.oe, (a.o.oval | b.o.pue), (b.o.pue | (b.o.oe & b.o.oval))) & b.o.ie
+  }
 }

--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -32,16 +32,16 @@ case class GPIOParams(
   * abstract over the bus protocol to which it is being connected
   */
 abstract class GPIO(busWidthBytes: Int, c: GPIOParams)(implicit p: Parameters)
-    extends PeripheralPuncher(
-      PeripheralPuncherParams(
+    extends IORegisterRouter(
+      RegisterRouterParams(
         name = "gpio",
         compat = Seq("sifive,gpio0"),
         base = c.address,
         beatBytes = busWidthBytes),
       new GPIOPortIO(c))
-    with HasCrossableInterrupts {
+    with HasInterruptSources {
 
-  override def nInterrupts = c.width
+  def nInterrupts = c.width
   override def extraResources(resources: ResourceBindings) = Map(
     "gpio-controller"      -> Nil,
     "#gpio-cells"          -> Seq(ResourceInt(2)),
@@ -223,5 +223,4 @@ object GPIO {
 }
 
 class TLGPIO(busWidthBytes: Int, params: GPIOParams)(implicit p: Parameters)
-  extends GPIO(busWidthBytes, params)
-  with HasCrossableTLControlRegMap
+  extends GPIO(busWidthBytes, params) with HasTLControlRegMap

--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -2,102 +2,53 @@
 package sifive.blocks.devices.gpio
 
 import Chisel._
-import chisel3.experimental.MultiIOModule
 import sifive.blocks.devices.pinctrl.{PinCtrl, Pin, BasePin, EnhancedPin, EnhancedPinCtrl}
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.util.SynchronizerShiftReg
 import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.interrupts._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.subsystem._
-import freechips.rocketchip.util.AsyncResetRegVec
-
-case class GPIOParams(
-  address: BigInt,
-  width: Int,
-  includeIOF: Boolean = false,
-  crossingType: SubsystemClockCrossing = SynchronousCrossing())
-
-// This is the actual IOF interface.pa
-// Add a valid bit to indicate whether
-// there is something actually connected
-// to this.
-class IOFCtrl extends PinCtrl {
-  val valid = Bool()
-}
-
-// By default,
-object IOFCtrl {
-  def apply(): IOFCtrl = {
-    val iof = Wire(new IOFCtrl())
-    iof.valid := Bool(false)
-    iof.oval  := Bool(false)
-    iof.oe    := Bool(false)
-    iof.ie    := Bool(false)
-    iof
-  }
-}
-
-// Package up the inputs and outputs
-// for the IOF
-class IOFPin extends Pin {
-  val o  = new IOFCtrl().asOutput
-
-  def default(): Unit = {
-    this.o.oval  := Bool(false)
-    this.o.oe    := Bool(false)
-    this.o.ie    := Bool(false)
-    this.o.valid := Bool(false)
-  }
-
-  def inputPin(pue: Bool = Bool(false) /*ignored*/): Bool = {
-    this.o.oval := Bool(false)
-    this.o.oe   := Bool(false)
-    this.o.ie   := Bool(true)
-    this.i.ival
-  }
-  def outputPin(signal: Bool,
-    pue: Bool = Bool(false), /*ignored*/
-    ds: Bool = Bool(false), /*ignored*/
-    ie: Bool = Bool(false)
-  ): Unit = {
-    this.o.oval := signal
-    this.o.oe   := Bool(true)
-    this.o.ie   := ie
-  }
-}
-
-// Connect both the i and o side of the pin,
-// and drive the valid signal for the IOF.
-object BasePinToIOF {
-  def apply(pin: BasePin, iof: IOFPin): Unit = {
-    iof <> pin
-    iof.o.valid := Bool(true)
-  }
-}
+import freechips.rocketchip.util.{AsyncResetRegVec, SynchronizerShiftReg}
 
 // This is sort of weird because
 // the IOF end up at the RocketChipTop
 // level, and we have to do the pinmux
 // outside of RocketChipTop.
+// It would be better if the IOF were here and
+// we could do the pinmux inside.
 
-class GPIOPortIO(private val c: GPIOParams) extends Bundle {
+class GPIOPortIO(val c: GPIOParams) extends Bundle {
   val pins = Vec(c.width, new EnhancedPin())
   val iof_0 = if (c.includeIOF) Some(Vec(c.width, new IOFPin).flip) else None
   val iof_1 = if (c.includeIOF) Some(Vec(c.width, new IOFPin).flip) else None
 }
 
-// It would be better if the IOF were here and
-// we could do the pinmux inside.
-trait HasGPIOBundleContents extends Bundle {
-  def params: GPIOParams
-  val port = new GPIOPortIO(params)
-}
+case class GPIOParams(
+  address: BigInt,
+  width: Int,
+  includeIOF: Boolean = false)
 
-trait HasGPIOModuleContents extends MultiIOModule with HasRegMap {
-  val io: HasGPIOBundleContents
-  val params: GPIOParams
-  val c = params
+/** The base GPIO peripheral functionality, which uses the regmap API to
+  * abstract over the bus protocol to which it is being connected
+  */
+abstract class GPIO(busWidthBytes: Int, c: GPIOParams)(implicit p: Parameters)
+    extends PeripheralPuncher(
+      PeripheralPuncherParams(
+        name = "gpio",
+        compat = Seq("sifive,gpio0"),
+        base = c.address,
+        beatBytes = busWidthBytes),
+      new GPIOPortIO(c))
+    with HasCrossableInterrupts {
+
+  override def nInterrupts = c.width
+  override def extraResources(resources: ResourceBindings) = Map(
+    "gpio-controller"      -> Nil,
+    "#gpio-cells"          -> Seq(ResourceInt(2)),
+    "interrupt-controller" -> Nil,
+    "#interrupt-cells"     -> Seq(ResourceInt(2)))
+
+  lazy val module = new LazyModuleImp(this) {
 
   //--------------------------------------------------
   // CSR Declarations
@@ -113,7 +64,7 @@ trait HasGPIOModuleContents extends MultiIOModule with HasRegMap {
 
   // Synchronize Input to get valueReg
   val inVal = Wire(UInt(0, width=c.width))
-  inVal := Vec(io.port.pins.map(_.i.ival)).asUInt
+  inVal := Vec(port.pins.map(_.i.ival)).asUInt
   val inSyncReg  = SynchronizerShiftReg(inVal, 3, Some("inSyncReg"))
   val valueReg   = Reg(init = UInt(0, c.width), next = inSyncReg)
 
@@ -211,13 +162,13 @@ trait HasGPIOModuleContents extends MultiIOModule with HasRegMap {
     if (c.includeIOF) {
       // Allow SW Override for invalid inputs.
       iof0Ctrl(pin)      <> swPinCtrl(pin)
-      when (io.port.iof_0.get(pin).o.valid) {
-        iof0Ctrl(pin)    <> io.port.iof_0.get(pin).o
+      when (port.iof_0.get(pin).o.valid) {
+        iof0Ctrl(pin)    <> port.iof_0.get(pin).o
       }
 
       iof1Ctrl(pin)      <> swPinCtrl(pin)
-      when (io.port.iof_1.get(pin).o.valid) {
-        iof1Ctrl(pin)    <> io.port.iof_1.get(pin).o
+      when (port.iof_1.get(pin).o.valid) {
+        iof1Ctrl(pin)    <> port.iof_1.get(pin).o
       }
 
       // Select IOF 0 vs. IOF 1.
@@ -233,8 +184,8 @@ trait HasGPIOModuleContents extends MultiIOModule with HasRegMap {
       pre_xor := swPinCtrl(pin)
     }
 
-    io.port.pins(pin).o      := pre_xor
-    io.port.pins(pin).o.oval := pre_xor.oval ^ xorReg(pin)
+    port.pins(pin).o      := pre_xor
+    port.pins(pin).o.oval := pre_xor.oval ^ xorReg(pin)
 
     // Generate Interrupts
     interrupts(pin) := (riseIpReg(pin) & riseIeReg(pin)) |
@@ -244,23 +195,33 @@ trait HasGPIOModuleContents extends MultiIOModule with HasRegMap {
 
     if (c.includeIOF) {
       // Send Value to all consumers
-      io.port.iof_0.get(pin).i.ival := inSyncReg(pin)
-      io.port.iof_1.get(pin).i.ival := inSyncReg(pin)
+      port.iof_0.get(pin).i.ival := inSyncReg(pin)
+      port.iof_1.get(pin).i.ival := inSyncReg(pin)
     }
+  }}
+}
+
+case class AttachedGPIOParams(
+  gpio: GPIOParams,
+  controlXType: ClockCrossingType = NoCrossing,
+  intXType: ClockCrossingType = NoCrossing)
+
+object GPIO {
+  def attach(params: AttachedGPIOParams, controlBus: TLBusWrapper, intNode: IntInwardNode, mclock: Option[ModuleValue[Clock]])
+            (implicit p: Parameters, valName: ValName): TLGPIO = {
+
+    val gpio = LazyModule(new TLGPIO(controlBus.beatBytes, params.gpio))
+
+    controlBus.coupleTo(s"slave_named_${valName.name}") {
+      gpio.controlXing(params.controlXType) := TLFragmenter(controlBus.beatBytes, controlBus.blockBytes) := _
+    }
+    intNode := gpio.intXing(params.intXType)
+    InModuleBody { gpio.module.clock := mclock.map(_.getWrappedValue).getOrElse(controlBus.module.clock) }
+
+    gpio
   }
 }
 
-// Magic TL2 Incantation to create a TL2 Slave
-class TLGPIO(w: Int, c: GPIOParams)(implicit p: Parameters)
-  extends TLRegisterRouter(c.address, "gpio", Seq("sifive,gpio0"), interrupts = c.width, beatBytes = w)(
-  new TLRegBundle(c, _)    with HasGPIOBundleContents)(
-  new TLRegModule(c, _, _) with HasGPIOModuleContents)
-  with HasCrossing
-{
-  val crossing = c.crossingType
-  override def extraResources(resources: ResourceBindings) = Map(
-    "gpio-controller"      -> Nil,
-    "#gpio-cells"          -> Seq(ResourceInt(2)),
-    "interrupt-controller" -> Nil,
-    "#interrupt-cells"     -> Seq(ResourceInt(2)))
-}
+class TLGPIO(busWidthBytes: Int, params: GPIOParams)(implicit p: Parameters)
+  extends GPIO(busWidthBytes, params)
+  with HasCrossableTLControlRegMap

--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -201,6 +201,9 @@ abstract class GPIO(busWidthBytes: Int, c: GPIOParams)(implicit p: Parameters)
   }}
 }
 
+class TLGPIO(busWidthBytes: Int, params: GPIOParams)(implicit p: Parameters)
+  extends GPIO(busWidthBytes, params) with HasTLControlRegMap
+
 case class AttachedGPIOParams(
   gpio: GPIOParams,
   controlXType: ClockCrossingType = NoCrossing,
@@ -221,6 +224,3 @@ object GPIO {
     gpio
   }
 }
-
-class TLGPIO(busWidthBytes: Int, params: GPIOParams)(implicit p: Parameters)
-  extends GPIO(busWidthBytes, params) with HasTLControlRegMap

--- a/src/main/scala/devices/gpio/GPIOPeriphery.scala
+++ b/src/main/scala/devices/gpio/GPIOPeriphery.scala
@@ -1,34 +1,24 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.gpio
 
-import Chisel._
 import freechips.rocketchip.config.Field
+import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.BaseSubsystem
-import freechips.rocketchip.diplomacy.{LazyModule,LazyModuleImp}
-import freechips.rocketchip.util.HeterogeneousBag
 
 case object PeripheryGPIOKey extends Field[Seq[GPIOParams]]
 
 trait HasPeripheryGPIO { this: BaseSubsystem =>
-  val gpioParams = p(PeripheryGPIOKey)
-  val gpios = gpioParams.zipWithIndex.map { case(params, i) =>
-    val name = Some(s"gpio_$i")
-    val gpio = LazyModule(new TLGPIO(pbus.beatBytes, params)).suggestName(name)
-    pbus.toVariableWidthSlave(name) { gpio.node }
-    ibus.fromAsync := gpio.intnode
-    gpio
+  val gpios = p(PeripheryGPIOKey).map { ps =>
+    GPIO.attach(AttachedGPIOParams(ps), pbus, ibus.fromAsync, None)
   }
+  val gpioNodes = gpios.map(_.ioNode.makeSink())
 }
 
 trait HasPeripheryGPIOBundle {
-  val gpio: HeterogeneousBag[GPIOPortIO]
+  val gpio: Seq[GPIOPortIO]
 }
 
 trait HasPeripheryGPIOModuleImp extends LazyModuleImp with HasPeripheryGPIOBundle {
   val outer: HasPeripheryGPIO
-  val gpio = IO(HeterogeneousBag(outer.gpioParams.map(new GPIOPortIO(_))))
-
-  (gpio zip outer.gpios) foreach { case (io, device) =>
-    io <> device.module.io.port
-  }
+  val gpio = outer.gpioNodes.map(_.makeIO())
 }

--- a/src/main/scala/devices/gpio/GPIOPeriphery.scala
+++ b/src/main/scala/devices/gpio/GPIOPeriphery.scala
@@ -20,5 +20,5 @@ trait HasPeripheryGPIOBundle {
 
 trait HasPeripheryGPIOModuleImp extends LazyModuleImp with HasPeripheryGPIOBundle {
   val outer: HasPeripheryGPIO
-  val gpio = outer.gpioNodes.map(_.makeIO())
+  val gpio = outer.gpioNodes.zipWithIndex.map { case(n,i) => n.makeIO()(ValName(s"gpio_$i")) }
 }

--- a/src/main/scala/devices/gpio/IOF.scala
+++ b/src/main/scala/devices/gpio/IOF.scala
@@ -1,0 +1,64 @@
+// See LICENSE for license details.
+package sifive.blocks.devices.gpio
+
+import Chisel._
+import sifive.blocks.devices.pinctrl.{PinCtrl, Pin, BasePin, EnhancedPin, EnhancedPinCtrl}
+
+// This is the actual IOF interface.pa
+// Add a valid bit to indicate whether
+// there is something actually connected
+// to this.
+class IOFCtrl extends PinCtrl {
+  val valid = Bool()
+}
+
+// By default,
+object IOFCtrl {
+  def apply(): IOFCtrl = {
+    val iof = Wire(new IOFCtrl())
+    iof.valid := Bool(false)
+    iof.oval  := Bool(false)
+    iof.oe    := Bool(false)
+    iof.ie    := Bool(false)
+    iof
+  }
+}
+
+// Package up the inputs and outputs
+// for the IOF
+class IOFPin extends Pin {
+  val o  = new IOFCtrl().asOutput
+
+  def default(): Unit = {
+    this.o.oval  := Bool(false)
+    this.o.oe    := Bool(false)
+    this.o.ie    := Bool(false)
+    this.o.valid := Bool(false)
+  }
+
+  def inputPin(pue: Bool = Bool(false) /*ignored*/): Bool = {
+    this.o.oval := Bool(false)
+    this.o.oe   := Bool(false)
+    this.o.ie   := Bool(true)
+    this.i.ival
+  }
+  def outputPin(signal: Bool,
+    pue: Bool = Bool(false), /*ignored*/
+    ds: Bool = Bool(false), /*ignored*/
+    ie: Bool = Bool(false)
+  ): Unit = {
+    this.o.oval := signal
+    this.o.oe   := Bool(true)
+    this.o.ie   := ie
+  }
+}
+
+// Connect both the i and o side of the pin,
+// and drive the valid signal for the IOF.
+object BasePinToIOF {
+  def apply(pin: BasePin, iof: IOFPin): Unit = {
+    iof <> pin
+    iof.o.valid := Bool(true)
+  }
+}
+

--- a/src/main/scala/devices/i2c/I2C.scala
+++ b/src/main/scala/devices/i2c/I2C.scala
@@ -64,16 +64,16 @@ class I2CPort extends Bundle {
 }
 
 abstract class I2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters)
-    extends PeripheralPuncher(
-      PeripheralPuncherParams(
+    extends IORegisterRouter(
+      RegisterRouterParams(
         name = "i2c",
         compat = Seq("sifive,i2c0"),
         base = params.address,
         beatBytes = busWidthBytes),
       new I2CPort)
-    with HasCrossableInterrupts {
+    with HasInterruptSources {
 
-  override def nInterrupts = 1
+  def nInterrupts = 1
 
   lazy val module = new LazyModuleImp(this) {
 
@@ -591,5 +591,4 @@ object I2C {
 }
 
 class TLI2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters)
-  extends I2C(busWidthBytes, params)
-  with HasCrossableTLControlRegMap
+  extends I2C(busWidthBytes, params) with HasTLControlRegMap

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -3,31 +3,23 @@ package sifive.blocks.devices.i2c
 
 import Chisel._
 import freechips.rocketchip.config.Field
+import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.{BaseSubsystem}
-import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 
 case object PeripheryI2CKey extends Field[Seq[I2CParams]]
 
 trait HasPeripheryI2C { this: BaseSubsystem =>
-  val i2cParams = p(PeripheryI2CKey)
-  val i2c = i2cParams.zipWithIndex.map { case(params, i) =>
-    val name = Some(s"i2c_$i")
-    val i2c = LazyModule(new TLI2C(pbus.beatBytes, params)).suggestName(name)
-    pbus.toVariableWidthSlave(name) { i2c.node }
-    ibus.fromAsync := i2c.intnode
-    i2c
+  val i2cs =  p(PeripheryI2CKey).map { ps =>
+    I2C.attach(AttachedI2CParams(ps), pbus, ibus.fromSync, None)
   }
+  val i2cNodes = i2cs.map(_.ioNode.makeSink())
 }
 
 trait HasPeripheryI2CBundle {
-  val i2c: Vec[I2CPort]
+  val i2c: Seq[I2CPort]
 }
 
 trait HasPeripheryI2CModuleImp extends LazyModuleImp with HasPeripheryI2CBundle {
   val outer: HasPeripheryI2C
-  val i2c = IO(Vec(outer.i2cParams.size, new I2CPort))
-
-  (i2c zip outer.i2c).foreach { case (io, device) =>
-    io <> device.module.io.port
-  }
+  val i2c = outer.i2cNodes.map(_.makeIO())
 }

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -21,5 +21,5 @@ trait HasPeripheryI2CBundle {
 
 trait HasPeripheryI2CModuleImp extends LazyModuleImp with HasPeripheryI2CBundle {
   val outer: HasPeripheryI2C
-  val i2c = outer.i2cNodes.map(_.makeIO())
+  val i2c  = outer.i2cNodes.zipWithIndex.map  { case(n,i) => n.makeIO()(ValName(s"i2c_$i")) }
 }

--- a/src/main/scala/devices/pwm/PWM.scala
+++ b/src/main/scala/devices/pwm/PWM.scala
@@ -88,6 +88,9 @@ abstract class PWM(busWidthBytes: Int, val params: PWMParams)(implicit p: Parame
   }
 }
 
+class TLPWM(busWidthBytes: Int, params: PWMParams)(implicit p: Parameters)
+  extends PWM(busWidthBytes, params) with HasTLControlRegMap
+
 case class AttachedPWMParams(
   pwm: PWMParams,
   controlXType: ClockCrossingType = NoCrossing,
@@ -107,6 +110,3 @@ object PWM {
     pwm
   }
 }
-
-class TLPWM(busWidthBytes: Int, params: PWMParams)(implicit p: Parameters)
-  extends PWM(busWidthBytes, params) with HasTLControlRegMap

--- a/src/main/scala/devices/pwm/PWM.scala
+++ b/src/main/scala/devices/pwm/PWM.scala
@@ -68,17 +68,17 @@ class PWMPortIO(val c: PWMParams) extends Bundle {
 }
 
 abstract class PWM(busWidthBytes: Int, val params: PWMParams)(implicit p: Parameters)
-    extends PeripheralPuncher(
-      PeripheralPuncherParams(
+    extends IORegisterRouter(
+      RegisterRouterParams(
         name = "pwm",
         compat = Seq("sifive,pwm0"),
         base = params.address,
         size = params.size,
         beatBytes = busWidthBytes),
       new PWMPortIO(params))
-    with HasCrossableInterrupts {
+    with HasInterruptSources {
 
-  override def nInterrupts = params.ncmp
+  def nInterrupts = params.ncmp
 
   lazy val module = new LazyModuleImp(this) {
     val pwm = Module(new PWMTimer(params.ncmp, params.cmpWidth))
@@ -109,5 +109,4 @@ object PWM {
 }
 
 class TLPWM(busWidthBytes: Int, params: PWMParams)(implicit p: Parameters)
-  extends PWM(busWidthBytes, params)
-  with HasCrossableTLControlRegMap
+  extends PWM(busWidthBytes, params) with HasTLControlRegMap

--- a/src/main/scala/devices/pwm/PWM.scala
+++ b/src/main/scala/devices/pwm/PWM.scala
@@ -2,18 +2,18 @@
 package sifive.blocks.devices.pwm
 
 import Chisel._
-import chisel3.experimental.MultiIOModule
 import Chisel.ImplicitConversions._
+import chisel3.experimental.MultiIOModule
 import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.interrupts._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.subsystem._
 import freechips.rocketchip.util._
 import sifive.blocks.util.{GenericTimer, GenericTimerIO, DefaultGenericTimerCfgDescs}
 
 // Core PWM Functionality  & Register Interface
-
-class PWM(val ncmp: Int = 4, val cmpWidth: Int = 16) extends MultiIOModule with GenericTimer {
+class PWMTimer(val ncmp: Int = 4, val cmpWidth: Int = 16) extends MultiIOModule with GenericTimer {
 
   def orR(v: Vec[Bool]): Bool = v.foldLeft(Bool(false))( _||_ )
 
@@ -61,30 +61,53 @@ case class PWMParams(
   size: Int = 0x1000,
   regBytes: Int = 4,
   ncmp: Int = 4,
-  cmpWidth: Int = 16,
-  crossingType: SubsystemClockCrossing = SynchronousCrossing())
+  cmpWidth: Int = 16)
 
-trait HasPWMBundleContents extends Bundle {
-  def params: PWMParams
-  val gpio = Vec(params.ncmp, Bool()).asOutput
+class PWMPortIO(val c: PWMParams) extends Bundle {
+  val gpio = Vec(c.ncmp, Bool()).asOutput
 }
 
-trait HasPWMModuleContents extends MultiIOModule with HasRegMap {
-  val io: HasPWMBundleContents
-  val params: PWMParams
+abstract class PWM(busWidthBytes: Int, val params: PWMParams)(implicit p: Parameters)
+    extends PeripheralPuncher(
+      PeripheralPuncherParams(
+        name = "pwm",
+        compat = Seq("sifive,pwm0"),
+        base = params.address,
+        size = params.size,
+        beatBytes = busWidthBytes),
+      new PWMPortIO(params))
+    with HasCrossableInterrupts {
 
-  val pwm = Module(new PWM(params.ncmp, params.cmpWidth))
+  override def nInterrupts = params.ncmp
 
-  interrupts := pwm.io.ip
-  io.gpio := pwm.io.gpio
-
-  regmap((GenericTimer.timerRegMap(pwm, 0, params.regBytes)):_*)
+  lazy val module = new LazyModuleImp(this) {
+    val pwm = Module(new PWMTimer(params.ncmp, params.cmpWidth))
+    interrupts := pwm.io.ip
+    port.gpio := pwm.io.gpio
+    regmap((GenericTimer.timerRegMap(pwm, 0, params.regBytes)):_*)
+  }
 }
 
-class TLPWM(w: Int, c: PWMParams)(implicit p: Parameters)
-  extends TLRegisterRouter(c.address, "pwm", Seq("sifive,pwm0"), interrupts = c.ncmp, size = c.size, beatBytes = w)(
-  new TLRegBundle(c, _)    with HasPWMBundleContents)(
-  new TLRegModule(c, _, _) with HasPWMModuleContents)
-  with HasCrossing{
-  val crossing = c.crossingType
+case class AttachedPWMParams(
+  pwm: PWMParams,
+  controlXType: ClockCrossingType = NoCrossing,
+  intXType: ClockCrossingType = NoCrossing)
+
+object PWM {
+  def attach(params: AttachedPWMParams, controlBus: TLBusWrapper, intNode: IntInwardNode, mclock: Option[ModuleValue[Clock]])
+            (implicit p: Parameters, valName: ValName): TLPWM = {
+    val pwm = LazyModule(new TLPWM(controlBus.beatBytes, params.pwm))
+
+    controlBus.coupleTo(s"slave_named_${valName.name}") {
+      pwm.controlXing(params.controlXType) := TLFragmenter(controlBus.beatBytes, controlBus.blockBytes) := _
+    }
+    intNode := pwm.intXing(params.intXType)
+    InModuleBody { pwm.module.clock := mclock.map(_.getWrappedValue).getOrElse(controlBus.module.clock) }
+
+    pwm
+  }
 }
+
+class TLPWM(busWidthBytes: Int, params: PWMParams)(implicit p: Parameters)
+  extends PWM(busWidthBytes, params)
+  with HasCrossableTLControlRegMap

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -3,39 +3,23 @@ package sifive.blocks.devices.pwm
 
 import Chisel._
 import freechips.rocketchip.config.Field
+import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.BaseSubsystem
-import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
-import freechips.rocketchip.util.HeterogeneousBag
-import sifive.blocks.devices.pinctrl.{Pin}
-
-class PWMPortIO(val c: PWMParams) extends Bundle {
-  val port = Vec(c.ncmp, Bool()).asOutput
-}
-
 
 case object PeripheryPWMKey extends Field[Seq[PWMParams]]
 
 trait HasPeripheryPWM { this: BaseSubsystem =>
-  val pwmParams = p(PeripheryPWMKey)
-  val pwms = pwmParams.zipWithIndex.map { case(params, i) =>
-    val name = Some(s"pwm_$i")
-    val pwm = LazyModule(new TLPWM(pbus.beatBytes, params)).suggestName(name)
-    pbus.toVariableWidthSlave(name) { pwm.node }
-    ibus.fromAsync := pwm.intnode
-    pwm
+  val pwms = p(PeripheryPWMKey).map { ps =>
+    PWM.attach(AttachedPWMParams(ps), pbus, ibus.fromSync, None)
   }
+  val pwmNodes = pwms.map(_.ioNode.makeSink())
 }
 
 trait HasPeripheryPWMBundle {
-  val pwm: HeterogeneousBag[PWMPortIO]
-
+  val pwm: Seq[PWMPortIO]
 }
 
 trait HasPeripheryPWMModuleImp extends LazyModuleImp with HasPeripheryPWMBundle {
   val outer: HasPeripheryPWM
-  val pwm = IO(HeterogeneousBag(outer.pwmParams.map(new PWMPortIO(_))))
-
-  (pwm zip outer.pwms) foreach { case (io, device) =>
-    io.port := device.module.io.gpio
-  }
+  val pwm = outer.pwmNodes.map(_.makeIO())
 }

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -21,5 +21,5 @@ trait HasPeripheryPWMBundle {
 
 trait HasPeripheryPWMModuleImp extends LazyModuleImp with HasPeripheryPWMBundle {
   val outer: HasPeripheryPWM
-  val pwm = outer.pwmNodes.map(_.makeIO())
+  val pwm  = outer.pwmNodes.zipWithIndex.map  { case(n,i) => n.makeIO()(ValName(s"pwm_$i")) }
 }

--- a/src/main/scala/devices/pwm/PWMPins.scala
+++ b/src/main/scala/devices/pwm/PWMPins.scala
@@ -14,14 +14,14 @@ class PWMPins[T <: Pin](pingen: () => T, c: PWMParams) extends PWMSignals[T](pin
 object PWMPinsFromPort {
   def apply[T <: Pin] (pins: PWMSignals[T], port: PWMPortIO, clock: Clock, reset: Bool): Unit = {
     withClockAndReset(clock, reset){
-      (pins.pwm zip port.port) foreach { case (pin, port) =>
+      (pins.pwm zip port.gpio) foreach { case (pin, port) =>
         pin.outputPin(port)
       }
     }
   }
 
   def apply[T <: Pin] (pins: PWMSignals[T], port: PWMPortIO): Unit = {
-    (pins.pwm zip port.port) foreach { case (pin, port) =>
+    (pins.pwm zip port.gpio) foreach { case (pin, port) =>
       pin.outputPin(port)
     }
   }

--- a/src/main/scala/devices/spi/SPI.scala
+++ b/src/main/scala/devices/spi/SPI.scala
@@ -1,0 +1,62 @@
+// See LICENSE for license details.
+package sifive.blocks.devices.spi
+
+import Chisel._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.interrupts._
+import freechips.rocketchip.regmapper._
+import freechips.rocketchip.tilelink._
+
+case class AttachedSPIParams(
+  spi: SPIParams,
+  controlXType: ClockCrossingType = NoCrossing,
+  intXType: ClockCrossingType = NoCrossing)
+
+case class AttachedSPIFlashParams(
+  qspi: SPIFlashParams,
+  fBufferDepth: Int = 0,
+  controlXType: ClockCrossingType = NoCrossing,
+  intXType: ClockCrossingType = NoCrossing,
+  memXType: ClockCrossingType = NoCrossing)
+
+object SPI {
+  def attach(params: AttachedSPIParams, controlBus: TLBusWrapper, intNode: IntInwardNode, mclock: Option[ModuleValue[Clock]])
+            (implicit p: Parameters, valName: ValName): TLSPI = {
+    val spi = LazyModule(new TLSPI(controlBus.beatBytes, params.spi))
+
+    controlBus.coupleTo(s"slave_named_${valName.name}") {
+      spi.controlXing(params.controlXType) := TLFragmenter(controlBus.beatBytes, controlBus.blockBytes) := _
+    }
+
+    intNode := spi.intXing(params.intXType)
+
+    InModuleBody { spi.module.clock := mclock.map(_.getWrappedValue).getOrElse(controlBus.module.clock) }
+
+    spi
+  }
+
+  def attachFlash(params: AttachedSPIFlashParams, controlBus: TLBusWrapper, memBus: TLBusWrapper, intNode: IntInwardNode, mclock: Option[ModuleValue[Clock]])
+            (implicit p: Parameters, valName: ValName): TLSPIFlash = {
+
+    val qspi = LazyModule(new TLSPIFlash(controlBus.beatBytes, params.qspi))
+
+    controlBus.coupleTo(s"slave_named_${valName.name}") {
+      qspi.controlXing(params.controlXType) := TLFragmenter(controlBus.beatBytes, controlBus.blockBytes) := _
+    }
+
+    memBus.coupleTo(s"mem_named_${valName.name}") {
+      (qspi.memXing(params.memXType)
+        := TLFragmenter(1, memBus.blockBytes)
+        := TLBuffer(BufferParams(params.fBufferDepth), BufferParams.none)
+        := TLWidthWidget(memBus.beatBytes)
+        := _)
+    }
+
+    intNode := qspi.intXing(params.intXType)
+
+    InModuleBody { qspi.module.clock := mclock.map(_.getWrappedValue).getOrElse(controlBus.module.clock) }
+
+    qspi
+  }
+}

--- a/src/main/scala/devices/spi/SPI.scala
+++ b/src/main/scala/devices/spi/SPI.scala
@@ -59,4 +59,16 @@ object SPI {
 
     qspi
   }
+
+  def synchronize(q: SPIPortIO): SPIPortIO = {
+    val x = Wire(new SPIPortIO(q.c))//, DontCare)
+    x.sck := q.sck
+    x.cs := q.cs
+    q.dq.zip(x.dq).foreach { case(qq,xx) =>
+      qq.i := ShiftRegister(xx.i, q.c.sampleDelay)
+      xx.o := qq.o
+      xx.oe := qq.oe
+    }
+    x
+  }
 }

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -4,64 +4,41 @@ package sifive.blocks.devices.spi
 import Chisel._
 import freechips.rocketchip.config.Field
 import freechips.rocketchip.subsystem.{BaseSubsystem}
-import freechips.rocketchip.diplomacy.{LazyModule,LazyModuleImp,BufferParams}
-import freechips.rocketchip.tilelink.{TLFragmenter,TLBuffer}
-import freechips.rocketchip.util.HeterogeneousBag
+import freechips.rocketchip.diplomacy._
 
 case object PeripherySPIKey extends Field[Seq[SPIParams]]
 
 trait HasPeripherySPI { this: BaseSubsystem =>
   val spiParams = p(PeripherySPIKey)  
-  val spis = spiParams.zipWithIndex.map { case(params, i) =>
-    val name = Some(s"spi_$i")
-    val spi = LazyModule(new TLSPI(pbus.beatBytes, params)).suggestName(name)
-    pbus.toVariableWidthSlave(name) { spi.rnode }
-    ibus.fromAsync := spi.intnode
-    spi
+  val spis = p(PeripherySPIKey).map { ps =>
+    SPI.attach(AttachedSPIParams(ps), pbus, ibus.fromSync, None)
   }
+  val spiNodes = spis.map(_.ioNode.makeSink())
 }
 
 trait HasPeripherySPIBundle {
-  val spi: HeterogeneousBag[SPIPortIO]
-
+  val spi: Seq[SPIPortIO]
 }
 
 trait HasPeripherySPIModuleImp extends LazyModuleImp with HasPeripherySPIBundle {
   val outer: HasPeripherySPI
-  val spi = IO(HeterogeneousBag(outer.spiParams.map(new SPIPortIO(_))))
-
-  (spi zip outer.spis).foreach { case (io, device) =>
-    io <> device.module.io.port
-  }
+  val spi = outer.spiNodes.map(_.makeIO())
 }
 
 case object PeripherySPIFlashKey extends Field[Seq[SPIFlashParams]]
 
 trait HasPeripherySPIFlash { this: BaseSubsystem =>
-  val spiFlashParams = p(PeripherySPIFlashKey)  
-  val qspis = spiFlashParams.zipWithIndex.map { case(params, i) =>
-    val name = Some(s"qspi_$i")
-    val qspi = LazyModule(new TLSPIFlash(pbus.beatBytes, params))
-    pbus.toVariableWidthSlave(name) { qspi.rnode }
-    qspi.fnode := pbus.toFixedWidthSlave(name) {
-      TLFragmenter(1, pbus.blockBytes) :=
-        TLBuffer(BufferParams(params.fBufferDepth), BufferParams.none)
-    }
-    ibus.fromAsync := qspi.intnode
-    qspi
+  val qspis = p(PeripherySPIFlashKey).map { ps =>
+    SPI.attachFlash(AttachedSPIFlashParams(ps, fBufferDepth = 8), pbus, pbus, ibus.fromSync, None)
   }
+  val qspiNodes = qspis.map(_.ioNode.makeSink())
 }
 
 trait HasPeripherySPIFlashBundle {
-  val qspi: HeterogeneousBag[SPIPortIO]
-
+  val qspi: Seq[SPIPortIO]
 }
 
 trait HasPeripherySPIFlashModuleImp extends LazyModuleImp with HasPeripherySPIFlashBundle {
   val outer: HasPeripherySPIFlash
-  val qspi = IO(HeterogeneousBag(outer.spiFlashParams.map(new SPIPortIO(_))))
-
-  (qspi zip outer.qspis) foreach { case (io, device) => 
-    io <> device.module.io.port
-  }
+  val qspi = outer.qspiNodes.map(_.makeIO())
 }

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -22,7 +22,7 @@ trait HasPeripherySPIBundle {
 
 trait HasPeripherySPIModuleImp extends LazyModuleImp with HasPeripherySPIBundle {
   val outer: HasPeripherySPI
-  val spi = outer.spiNodes.map(_.makeIO())
+  val spi  = outer.spiNodes.zipWithIndex.map  { case(n,i) => n.makeIO()(ValName(s"spi_$i")) }
 }
 
 case object PeripherySPIFlashKey extends Field[Seq[SPIFlashParams]]
@@ -40,5 +40,5 @@ trait HasPeripherySPIFlashBundle {
 
 trait HasPeripherySPIFlashModuleImp extends LazyModuleImp with HasPeripherySPIFlashBundle {
   val outer: HasPeripherySPIFlash
-  val qspi = outer.qspiNodes.map(_.makeIO())
+  val qspi = outer.qspiNodes.zipWithIndex.map { case(n,i) => n.makeIO()(ValName(s"qspi_$i")) }
 }

--- a/src/main/scala/devices/spi/TLSPI.scala
+++ b/src/main/scala/devices/spi/TLSPI.scala
@@ -43,7 +43,7 @@ case class SPIParams(
     delayBits: Int = 8,
     divisorBits: Int = 12,
     sampleDelay: Int = 2,
-    crossingType: SubsystemClockCrossing = SynchronousCrossing()
+    crossingType: ClockCrossingType = SynchronousCrossing()
     )
   extends SPIParamsBase {
 
@@ -52,17 +52,13 @@ case class SPIParams(
 }
 
 class SPITopModule(c: SPIParamsBase, outer: TLSPIBase)
-  extends LazyModuleImp(outer) {
-
-  val io = IO(new Bundle {
-    val port = new SPIPortIO(c)
-  })
+    extends LazyModuleImp(outer) {
 
   val ctrl = Reg(init = SPIControl.init(c))
 
   val fifo = Module(new SPIFIFO(c))
   val mac = Module(new SPIMedia(c))
-  io.port <> mac.io.port
+  outer.port <> mac.io.port
 
   fifo.io.ctrl.fmt := ctrl.fmt
   fifo.io.ctrl.cs <> ctrl.cs
@@ -73,8 +69,7 @@ class SPITopModule(c: SPIParamsBase, outer: TLSPIBase)
 
   val ie = Reg(init = new SPIInterrupts().fromBits(Bits(0)))
   val ip = fifo.io.ip
-  val (io_int, _) = outer.intnode.out(0)
-  io_int(0) := (ip.txwm && ie.txwm) || (ip.rxwm && ie.rxwm)
+  outer.interrupts(0) := (ip.txwm && ie.txwm) || (ip.rxwm && ie.rxwm)
 
   protected val regmapBase = Seq(
     SPICRs.sckdiv -> Seq(RegField(c.divisorBits, ctrl.sck.div,
@@ -156,27 +151,27 @@ class FlashDevice(spi: Device, bits: Int = 4, maxMHz: Double = 50, compat: Seq[S
   }
 }
 
-abstract class TLSPIBase(w: Int, c: SPIParamsBase)(implicit p: Parameters) extends LazyModule {
+abstract class TLSPIBase(w: Int, c: SPIParamsBase)(implicit p: Parameters) extends PeripheralPuncher(
+      PeripheralPuncherParams(
+        name = "spi",
+        compat = Seq("sifive,spi0"),
+        base = c.rAddress,
+        size = c.rSize,
+        beatBytes = w),
+      new SPIPortIO(c))
+    with HasCrossableInterrupts {
   require(isPow2(c.rSize))
-  val device = new SimpleDevice("spi", Seq("sifive,spi0")) {
-    override def describe(resources: ResourceBindings): Description = {
-      val Description(name, mapping) = super.describe(resources)
-      val extra = Map(
+  override def extraResources(resources: ResourceBindings) = Map(
         "#address-cells" -> Seq(ResourceInt(1)),
         "#size-cells" -> Seq(ResourceInt(0)))
-      Description(name, mapping ++ extra)
-    }
-  }
-  val rnode = TLRegisterNode(address = Seq(AddressSet(c.rAddress, c.rSize-1)), device = device, beatBytes = w)
-  val intnode = IntSourceNode(IntSourcePortSimple(resources = device.int))
+  override def nInterrupts = 1
 }
 
 class TLSPI(w: Int, c: SPIParams)(implicit p: Parameters)
-  extends TLSPIBase(w,c)(p)
-  with HasCrossing{
-  val crossing = c.crossingType
+    extends TLSPIBase(w,c)(p)
+    with HasCrossableTLControlRegMap {
   lazy val module = new SPITopModule(c, this) {
     mac.io.link <> fifo.io.link
-    rnode.regmap(regmapBase:_*)
+    regmap(regmapBase:_*)
   }
 }

--- a/src/main/scala/devices/spi/TLSPI.scala
+++ b/src/main/scala/devices/spi/TLSPI.scala
@@ -151,15 +151,15 @@ class FlashDevice(spi: Device, bits: Int = 4, maxMHz: Double = 50, compat: Seq[S
   }
 }
 
-abstract class TLSPIBase(w: Int, c: SPIParamsBase)(implicit p: Parameters) extends PeripheralPuncher(
-      PeripheralPuncherParams(
+abstract class TLSPIBase(w: Int, c: SPIParamsBase)(implicit p: Parameters) extends IORegisterRouter(
+      RegisterRouterParams(
         name = "spi",
         compat = Seq("sifive,spi0"),
         base = c.rAddress,
         size = c.rSize,
         beatBytes = w),
       new SPIPortIO(c))
-    with HasCrossableInterrupts {
+    with HasInterruptSources {
   require(isPow2(c.rSize))
   override def extraResources(resources: ResourceBindings) = Map(
         "#address-cells" -> Seq(ResourceInt(1)),
@@ -168,8 +168,7 @@ abstract class TLSPIBase(w: Int, c: SPIParamsBase)(implicit p: Parameters) exten
 }
 
 class TLSPI(w: Int, c: SPIParams)(implicit p: Parameters)
-    extends TLSPIBase(w,c)(p)
-    with HasCrossableTLControlRegMap {
+    extends TLSPIBase(w,c)(p) with HasTLControlRegMap {
   lazy val module = new SPITopModule(c, this) {
     mac.io.link <> fifo.io.link
     regmap(regmapBase:_*)

--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -12,7 +12,6 @@ import freechips.rocketchip.util.HeterogeneousBag
 trait SPIFlashParamsBase extends SPIParamsBase {
   val fAddress: BigInt
   val fSize: BigInt
-  val fBufferDepth: Int
 
   val insnAddrBytes: Int
   val insnPadLenBits: Int
@@ -24,7 +23,6 @@ trait SPIFlashParamsBase extends SPIParamsBase {
 case class SPIFlashParams(
     rAddress: BigInt,
     fAddress: BigInt,
-    fBufferDepth: Int = 0,
     rSize: BigInt = 0x1000,
     fSize: BigInt = 0x20000000,
     rxDepth: Int = 8,
@@ -33,7 +31,7 @@ case class SPIFlashParams(
     delayBits: Int = 8,
     divisorBits: Int = 12,
     sampleDelay: Int = 2,
-    crossingType: SubsystemClockCrossing = SynchronousCrossing())
+    crossingType: ClockCrossingType = SynchronousCrossing())
   extends SPIFlashParamsBase {
   val frameBits = 8
   val insnAddrBytes = 4
@@ -113,17 +111,18 @@ abstract class TLSPIFlashBase(w: Int, c: SPIFlashParamsBase)(implicit p: Paramet
       supportsGet = TransferSizes(1, 1),
       fifoId      = Some(0))),
     beatBytes = 1)))
+  val memXing = this.crossIn(fnode)
 }
 
-class TLSPIFlash(w: Int, c: SPIFlashParams)(implicit p: Parameters) extends TLSPIFlashBase(w,c)(p) with HasCrossing {
-  val crossing = c.crossingType
-
+class TLSPIFlash(w: Int, c: SPIFlashParams)(implicit p: Parameters)
+    extends TLSPIFlashBase(w,c)(p)
+    with HasCrossableTLControlRegMap {
   lazy val module = new SPIFlashTopModule(c, this) {
 
     arb.io.inner(0) <> flash.io.link
     arb.io.inner(1) <> fifo.io.link
     mac.io.link <> arb.io.outer
 
-    rnode.regmap(regmapBase ++ regmapFlash:_*)
+    regmap(regmapBase ++ regmapFlash:_*)
   }
 }

--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -116,7 +116,7 @@ abstract class TLSPIFlashBase(w: Int, c: SPIFlashParamsBase)(implicit p: Paramet
 
 class TLSPIFlash(w: Int, c: SPIFlashParams)(implicit p: Parameters)
     extends TLSPIFlashBase(w,c)(p)
-    with HasCrossableTLControlRegMap {
+    with HasTLControlRegMap {
   lazy val module = new SPIFlashTopModule(c, this) {
 
     arb.io.inner(0) <> flash.io.link

--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -5,9 +5,8 @@ import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
-import freechips.rocketchip.tilelink._
 import freechips.rocketchip.regmapper._
-import freechips.rocketchip.util._
+import freechips.rocketchip.tilelink._
 
 import sifive.blocks.util.{NonBlockingEnqueue, NonBlockingDequeue}
 
@@ -15,7 +14,6 @@ case class UARTParams(
   address: BigInt,
   dataBits: Int = 8,
   stopBits: Int = 2,
-  divisorInit: Int = 0,
   divisorBits: Int = 16,
   oversample: Int = 4,
   nSamples: Int = 3,
@@ -31,146 +29,20 @@ class UARTPortIO extends Bundle {
   val rxd = Bool(INPUT)
 }
 
-class UARTTx(c: UARTParams)(implicit p: Parameters) extends Module {
-  val io = new Bundle {
-    val en = Bool(INPUT)
-    val in = Decoupled(Bits(width = c.dataBits)).flip
-    val out = Bits(OUTPUT, 1)
-    val div = UInt(INPUT, c.divisorBits)
-    val nstop = UInt(INPUT, log2Up(c.stopBits))
-  }
-
-  val prescaler = Reg(init = UInt(0, c.divisorBits))
-  val pulse = (prescaler === UInt(0))
-
-  private val n = c.dataBits + 1
-  val counter = Reg(init = UInt(0, log2Floor(n + c.stopBits) + 1))
-  val shifter = Reg(Bits(width = n))
-  val out = Reg(init = Bits(1, 1))
-  io.out := out
-
-  val plusarg_tx = PlusArg("uart_tx", 1, "Enable/disable the TX to speed up simulation").orR
-
-  val busy = (counter =/= UInt(0))
-  io.in.ready := io.en && !busy
-  when (io.in.fire()) {
-    printf("UART TX (%x): %c\n", io.in.bits, io.in.bits)
-  }
-  when (io.in.fire() && plusarg_tx) {
-    shifter := Cat(io.in.bits, Bits(0, 1))
-    counter := Mux1H((0 until c.stopBits).map(i =>
-      (io.nstop === UInt(i)) -> UInt(n + i + 1)))
-  }
-  when (busy) {
-    prescaler := Mux(pulse, io.div, prescaler - UInt(1))
-  }
-  when (pulse && busy) {
-    counter := counter - UInt(1)
-    shifter := Cat(Bits(1, 1), shifter >> 1)
-    out := shifter(0)
-  }
-}
-
-class UARTRx(c: UARTParams)(implicit p: Parameters) extends Module {
-  val io = new Bundle {
-    val en = Bool(INPUT)
-    val in = Bits(INPUT, 1)
-    val out = Valid(Bits(width = c.dataBits))
-    val div = UInt(INPUT, c.divisorBits)
-  }
-
-  val debounce = Reg(init = UInt(0, 2))
-  val debounce_max = (debounce === UInt(3))
-  val debounce_min = (debounce === UInt(0))
-
-  val prescaler = Reg(UInt(width = c.divisorBits - c.oversample + 1))
-  val start = Wire(init = Bool(false))
-  val pulse = (prescaler === UInt(0))
-
-  private val dataCountBits = log2Floor(c.dataBits) + 1
-
-  val data_count = Reg(UInt(width = dataCountBits))
-  val data_last = (data_count === UInt(0))
-  val sample_count = Reg(UInt(width = c.oversample))
-  val sample_mid = (sample_count === UInt((c.oversampleFactor - c.nSamples + 1) >> 1))
-  val sample_last = (sample_count === UInt(0))
-  val countdown = Cat(data_count, sample_count) - UInt(1)
-
-  // Compensate for the divisor not being a multiple of the oversampling period.
-  // Let remainder k = (io.div % c.oversampleFactor).
-  // For the last k samples, extend the sampling delay by 1 cycle.
-  val remainder = io.div(c.oversample-1, 0)
-  val extend = (sample_count < remainder) // Pad head: (sample_count > ~remainder)
-  val restore = start || pulse
-  val prescaler_in = Mux(restore, io.div >> c.oversample, prescaler)
-  val prescaler_next = prescaler_in - Mux(restore && extend, UInt(0), UInt(1))
-
-  val sample = Reg(Bits(width = c.nSamples))
-  val voter = Majority(sample.toBools.toSet)
-  val shifter = Reg(Bits(width = c.dataBits))
-
-  val valid = Reg(init = Bool(false))
-  valid := Bool(false)
-  io.out.valid := valid
-  io.out.bits := shifter
-
-  val (s_idle :: s_data :: Nil) = Enum(UInt(), 2)
-  val state = Reg(init = s_idle)
-
-  switch (state) {
-    is (s_idle) {
-      when (!(!io.in) && !debounce_min) {
-        debounce := debounce - UInt(1)
-      }
-      when (!io.in) {
-        debounce := debounce + UInt(1)
-        when (debounce_max) {
-          state := s_data
-          start := Bool(true)
-          prescaler := prescaler_next
-          data_count := UInt(c.dataBits+1)
-          sample_count := UInt(c.oversampleFactor - 1)
-        }
-      }
-    }
-
-    is (s_data) {
-      prescaler := prescaler_next
-      when (pulse) {
-        sample := Cat(sample, io.in)
-        data_count := countdown >> c.oversample
-        sample_count := countdown(c.oversample-1, 0)
-
-        when (sample_mid) {
-          when (data_last) {
-            state := s_idle
-            valid := Bool(true)
-          } .otherwise {
-            shifter := Cat(voter, shifter >> 1)
-          }
-        }
-      }
-    }
-  }
-
-  when (!io.en) {
-    debounce := UInt(0)
-  }
-}
-
 class UARTInterrupts extends Bundle {
   val rxwm = Bool()
   val txwm = Bool()
 }
 
-abstract class UART(busWidthBytes: Int, baseAddr: BigInt, val c: UARTParams, divisorInit: Int)(implicit p: Parameters)
+abstract class UART(busWidthBytes: Int, val c: UARTParams, divisorInit: Int = 0)
+                   (implicit p: Parameters)
     extends PeripheralPuncher(
-      devParams = PeripheralPuncherParams(
+      PeripheralPuncherParams(
         name = "serial",
         compat = Seq("sifive,uart0"), 
-        base = baseAddr,
-        beatBytes = busWidthBytes))(
-      portBundle = new UARTPortIO)
+        base = c.address,
+        beatBytes = busWidthBytes),
+      new UARTPortIO)
     with HasCrossableInterrupts {
 
   override def nInterrupts = 1
@@ -256,27 +128,31 @@ abstract class UART(busWidthBytes: Int, baseAddr: BigInt, val c: UARTParams, div
   )
 }}
 
-case class AttachedUARTParams(uart: UARTParams, baseAddress: BigInt, control: ClockCrossingType, int: ClockCrossingType, divinit: Int)
+case class AttachedUARTParams(
+  uart: UARTParams,
+  divinit: Int,
+  controlXType: ClockCrossingType = NoCrossing,
+  intXType: ClockCrossingType = NoCrossing)
 
 object UART {
-  def attach(name: String, params: AttachedUARTParams, controlBus: TLBusWrapper, intNode: IntInwardNode, mclock: ModuleValue[Clock])
-            (implicit p: Parameters): TLUART = {
-    val uart = LazyModule(new TLUART(controlBus.beatBytes, params.baseAddress, params.uart, params.divinit)).suggestName(name)
+  def attach(params: AttachedUARTParams, controlBus: TLBusWrapper, intNode: IntInwardNode, mclock: Option[ModuleValue[Clock]])
+            (implicit p: Parameters, valName: ValName): TLUART = {
+    val uart = LazyModule(new TLUART(controlBus.beatBytes, params.uart, params.divinit))
 
-    controlBus.coupleTo(s"slave_named_$name") {
-      uart.crossControl(params.control) := TLFragmenter(controlBus.beatBytes, controlBus.blockBytes)
+    controlBus.coupleTo(s"slave_named_${valName.name}") {
+      uart.controlXing(params.controlXType) := TLFragmenter(controlBus.beatBytes, controlBus.blockBytes) := _
     }
-    intNode := uart.crossInt(params.int)
-    InModuleBody { uart.module.clock := mclock }
+    intNode := uart.intXing(params.intXType)
+    InModuleBody { uart.module.clock := mclock.map(_.getWrappedValue).getOrElse(controlBus.module.clock) }
 
     uart
   }
 
-  def tieoff(uart: UARTPortIO) {
-    uart.rxd := UInt(1)
+  def tieoff(port: UARTPortIO) {
+    port.rxd := UInt(1)
   }
 }
 
-class TLUART(busWidthBytes: Int, baseAddress: BigInt, params: UARTParams, divinit: Int)(implicit p: Parameters)
-  extends UART(busWidthBytes, baseAddress, params, divinit)
+class TLUART(busWidthBytes: Int, params: UARTParams, divinit: Int)(implicit p: Parameters)
+  extends UART(busWidthBytes, params, divinit)
   with HasCrossableTLControlRegMap

--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -36,16 +36,16 @@ class UARTInterrupts extends Bundle {
 
 abstract class UART(busWidthBytes: Int, val c: UARTParams, divisorInit: Int = 0)
                    (implicit p: Parameters)
-    extends PeripheralPuncher(
-      PeripheralPuncherParams(
+    extends IORegisterRouter(
+      RegisterRouterParams(
         name = "serial",
         compat = Seq("sifive,uart0"), 
         base = c.address,
         beatBytes = busWidthBytes),
       new UARTPortIO)
-    with HasCrossableInterrupts {
+    with HasInterruptSources {
 
-  override def nInterrupts = 1
+  def nInterrupts = 1
 
   ResourceBinding {
     Resource(ResourceAnchors.aliases, "uart").bind(ResourceAlias(device.label))
@@ -154,5 +154,4 @@ object UART {
 }
 
 class TLUART(busWidthBytes: Int, params: UARTParams, divinit: Int)(implicit p: Parameters)
-  extends UART(busWidthBytes, params, divinit)
-  with HasCrossableTLControlRegMap
+  extends UART(busWidthBytes, params, divinit) with HasTLControlRegMap

--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -151,6 +151,10 @@ object UART {
   def tieoff(port: UARTPortIO) {
     port.rxd := UInt(1)
   }
+
+  def loopback(port: UARTPortIO) {
+    port.rxd := port.txd
+  }
 }
 
 class TLUART(busWidthBytes: Int, params: UARTParams, divinit: Int)(implicit p: Parameters)

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -1,40 +1,28 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.uart
 
-import Chisel._
-import chisel3.experimental.{withClockAndReset}
 import freechips.rocketchip.config.Field
-import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
-import freechips.rocketchip.subsystem.{BaseSubsystem, PeripheryBus, PeripheryBusKey}
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.subsystem.{BaseSubsystem, PeripheryBusKey}
 
 case object PeripheryUARTKey extends Field[Seq[UARTParams]]
 
 trait HasPeripheryUART { this: BaseSubsystem =>
-  private val divinit = (p(PeripheryBusKey).frequency / 115200).toInt
-  val uartParams = p(PeripheryUARTKey).map(_.copy(divisorInit = divinit))
-  val uarts = uartParams.zipWithIndex.map { case(params, i) =>
-    val name = Some(s"uart_$i")
-    val uart = LazyModule(new TLUART(pbus.beatBytes, params)).suggestName(name)
-    pbus.toVariableWidthSlave(name) { uart.node }
-    ibus.fromAsync := uart.intnode
-    uart
+  val uarts = p(PeripheryUARTKey).zipWithIndex.map { case(ps, i) =>
+    val divinit = (p(PeripheryBusKey).frequency / 115200).toInt
+    val params = AttachedUARTParams(ps, ps.address, NoCrossing, NoCrossing, divinit)
+    val mclock = InModuleBody { pbus.module.clock }
+    UART.attach(s"uart_$i", params, pbus, ibus.fromAsync, mclock)
   }
+  val uartNodes = uarts.map(_.ioNode.makeSink())
 }
 
 trait HasPeripheryUARTBundle {
-  val uart: Vec[UARTPortIO]
-
-  def tieoffUARTs(dummy: Int = 1) {
-    uart.foreach { _.rxd := UInt(1) }
-  }
-
+  val uart: Seq[UARTPortIO]
 }
+
 
 trait HasPeripheryUARTModuleImp extends LazyModuleImp with HasPeripheryUARTBundle {
   val outer: HasPeripheryUART
-  val uart = IO(Vec(outer.uartParams.size, new UARTPortIO))
-
-  (uart zip outer.uarts).foreach { case (io, device) =>
-    io <> device.module.io.port
-  }
+  val uart = outer.uartNodes.map(_.makeIO())
 }

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -8,11 +8,9 @@ import freechips.rocketchip.subsystem.{BaseSubsystem, PeripheryBusKey}
 case object PeripheryUARTKey extends Field[Seq[UARTParams]]
 
 trait HasPeripheryUART { this: BaseSubsystem =>
-  val uarts = p(PeripheryUARTKey).zipWithIndex.map { case(ps, i) =>
+  val uarts = p(PeripheryUARTKey).map { ps =>
     val divinit = (p(PeripheryBusKey).frequency / 115200).toInt
-    val params = AttachedUARTParams(ps, ps.address, NoCrossing, NoCrossing, divinit)
-    val mclock = InModuleBody { pbus.module.clock }
-    UART.attach(s"uart_$i", params, pbus, ibus.fromAsync, mclock)
+    UART.attach(AttachedUARTParams(ps, divinit), pbus, ibus.fromSync, None)
   }
   val uartNodes = uarts.map(_.ioNode.makeSink())
 }

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -22,5 +22,5 @@ trait HasPeripheryUARTBundle {
 
 trait HasPeripheryUARTModuleImp extends LazyModuleImp with HasPeripheryUARTBundle {
   val outer: HasPeripheryUART
-  val uart = outer.uartNodes.map(_.makeIO())
+  val uart = outer.uartNodes.zipWithIndex.map { case(n,i) => n.makeIO()(ValName(s"uart_$i")) }
 }

--- a/src/main/scala/devices/uart/UARTRx.scala
+++ b/src/main/scala/devices/uart/UARTRx.scala
@@ -1,0 +1,93 @@
+// See LICENSE for license details.
+package sifive.blocks.devices.uart
+
+import Chisel._
+
+import freechips.rocketchip.util.Majority
+
+class UARTRx(c: UARTParams) extends Module {
+  val io = new Bundle {
+    val en = Bool(INPUT)
+    val in = Bits(INPUT, 1)
+    val out = Valid(Bits(width = c.dataBits))
+    val div = UInt(INPUT, c.divisorBits)
+  }
+
+  val debounce = Reg(init = UInt(0, 2))
+  val debounce_max = (debounce === UInt(3))
+  val debounce_min = (debounce === UInt(0))
+
+  val prescaler = Reg(UInt(width = c.divisorBits - c.oversample + 1))
+  val start = Wire(init = Bool(false))
+  val pulse = (prescaler === UInt(0))
+
+  private val dataCountBits = log2Floor(c.dataBits) + 1
+
+  val data_count = Reg(UInt(width = dataCountBits))
+  val data_last = (data_count === UInt(0))
+  val sample_count = Reg(UInt(width = c.oversample))
+  val sample_mid = (sample_count === UInt((c.oversampleFactor - c.nSamples + 1) >> 1))
+  val sample_last = (sample_count === UInt(0))
+  val countdown = Cat(data_count, sample_count) - UInt(1)
+
+  // Compensate for the divisor not being a multiple of the oversampling period.
+  // Let remainder k = (io.div % c.oversampleFactor).
+  // For the last k samples, extend the sampling delay by 1 cycle.
+  val remainder = io.div(c.oversample-1, 0)
+  val extend = (sample_count < remainder) // Pad head: (sample_count > ~remainder)
+  val restore = start || pulse
+  val prescaler_in = Mux(restore, io.div >> c.oversample, prescaler)
+  val prescaler_next = prescaler_in - Mux(restore && extend, UInt(0), UInt(1))
+
+  val sample = Reg(Bits(width = c.nSamples))
+  val voter = Majority(sample.toBools.toSet)
+  val shifter = Reg(Bits(width = c.dataBits))
+
+  val valid = Reg(init = Bool(false))
+  valid := Bool(false)
+  io.out.valid := valid
+  io.out.bits := shifter
+
+  val (s_idle :: s_data :: Nil) = Enum(UInt(), 2)
+  val state = Reg(init = s_idle)
+
+  switch (state) {
+    is (s_idle) {
+      when (!(!io.in) && !debounce_min) {
+        debounce := debounce - UInt(1)
+      }
+      when (!io.in) {
+        debounce := debounce + UInt(1)
+        when (debounce_max) {
+          state := s_data
+          start := Bool(true)
+          prescaler := prescaler_next
+          data_count := UInt(c.dataBits+1)
+          sample_count := UInt(c.oversampleFactor - 1)
+        }
+      }
+    }
+
+    is (s_data) {
+      prescaler := prescaler_next
+      when (pulse) {
+        sample := Cat(sample, io.in)
+        data_count := countdown >> c.oversample
+        sample_count := countdown(c.oversample-1, 0)
+
+        when (sample_mid) {
+          when (data_last) {
+            state := s_idle
+            valid := Bool(true)
+          } .otherwise {
+            shifter := Cat(voter, shifter >> 1)
+          }
+        }
+      }
+    }
+  }
+
+  when (!io.en) {
+    debounce := UInt(0)
+  }
+}

--- a/src/main/scala/devices/uart/UARTTx.scala
+++ b/src/main/scala/devices/uart/UARTTx.scala
@@ -1,0 +1,46 @@
+// See LICENSE for license details.
+package sifive.blocks.devices.uart
+
+import Chisel._
+
+import freechips.rocketchip.util.PlusArg
+
+class UARTTx(c: UARTParams) extends Module {
+  val io = new Bundle {
+    val en = Bool(INPUT)
+    val in = Decoupled(Bits(width = c.dataBits)).flip
+    val out = Bits(OUTPUT, 1)
+    val div = UInt(INPUT, c.divisorBits)
+    val nstop = UInt(INPUT, log2Up(c.stopBits))
+  }
+
+  val prescaler = Reg(init = UInt(0, c.divisorBits))
+  val pulse = (prescaler === UInt(0))
+
+  private val n = c.dataBits + 1
+  val counter = Reg(init = UInt(0, log2Floor(n + c.stopBits) + 1))
+  val shifter = Reg(Bits(width = n))
+  val out = Reg(init = Bits(1, 1))
+  io.out := out
+
+  val plusarg_tx = PlusArg("uart_tx", 1, "Enable/disable the TX to speed up simulation").orR
+
+  val busy = (counter =/= UInt(0))
+  io.in.ready := io.en && !busy
+  when (io.in.fire()) {
+    printf("UART TX (%x): %c\n", io.in.bits, io.in.bits)
+  }
+  when (io.in.fire() && plusarg_tx) {
+    shifter := Cat(io.in.bits, Bits(0, 1))
+    counter := Mux1H((0 until c.stopBits).map(i =>
+      (io.nstop === UInt(i)) -> UInt(n + i + 1)))
+  }
+  when (busy) {
+    prescaler := Mux(pulse, io.div, prescaler - UInt(1))
+  }
+  when (pulse && busy) {
+    counter := counter - UInt(1)
+    shifter := Cat(Bits(1, 1), shifter >> 1)
+    out := shifter(0)
+  }
+}


### PR DESCRIPTION
The new `RegisterRouter` API has several advantages over the previously available `TLRegisterRouter` for IO devices:
- It does not require separate Bundle and ModuleImp traits for the controller implementation
- Its IO ports can be bridged to higher in the module hierarchy
- Its control register map can be clock crossed relative to the buses it is attached to

The above make it straightforward to capture the attachment of the controller to the buses in a helper object application, rather than in traits. This PR converts the GPIO, UART, PWM, I2C, SPI, and QSPI controllers, while reimplementing the behavior of the legacy traits used to attach them to `BaseSubsystems` to use `attach`. 