### PR TITLE
device attachment cleanups

### DIFF
--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -210,12 +210,13 @@ case class AttachedGPIOParams(
   intXType: ClockCrossingType = NoCrossing)
 
 object GPIO {
+  val nextId = { var i = -1; () => { i += 1; i} }
   def attach(params: AttachedGPIOParams, controlBus: TLBusWrapper, intNode: IntInwardNode, mclock: Option[ModuleValue[Clock]])
-            (implicit p: Parameters, valName: ValName): TLGPIO = {
-
+            (implicit p: Parameters): TLGPIO = {
+    val name = s"gpio_${nextId()}"
     val gpio = LazyModule(new TLGPIO(controlBus.beatBytes, params.gpio))
-
-    controlBus.coupleTo(s"slave_named_${valName.name}") {
+    gpio.suggestName(name)
+    controlBus.coupleTo(s"device_named_$name") {
       gpio.controlXing(params.controlXType) := TLFragmenter(controlBus.beatBytes, controlBus.blockBytes) := _
     }
     intNode := gpio.intXing(params.intXType)

--- a/src/main/scala/devices/i2c/I2C.scala
+++ b/src/main/scala/devices/i2c/I2C.scala
@@ -576,11 +576,14 @@ case class AttachedI2CParams(
   intXType: ClockCrossingType = NoCrossing)
 
 object I2C {
+  val nextId = { var i = -1; () => { i += 1; i} }
   def attach(params: AttachedI2CParams, controlBus: TLBusWrapper, intNode: IntInwardNode, mclock: Option[ModuleValue[Clock]])
-            (implicit p: Parameters, valName: ValName): TLI2C = {
+            (implicit p: Parameters): TLI2C = {
+    val name = s"i2c_${nextId()}"
     val i2c = LazyModule(new TLI2C(controlBus.beatBytes, params.i2c))
+    i2c.suggestName(name)
 
-    controlBus.coupleTo(s"slave_named_${valName.name}") {
+    controlBus.coupleTo(s"device_named_$name") {
       i2c.controlXing(params.controlXType) := TLFragmenter(controlBus.beatBytes, controlBus.blockBytes) := _
     }
     intNode := i2c.intXing(params.intXType)

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -10,7 +10,7 @@ case object PeripheryI2CKey extends Field[Seq[I2CParams]]
 
 trait HasPeripheryI2C { this: BaseSubsystem =>
   val i2cs =  p(PeripheryI2CKey).map { ps =>
-    I2C.attach(AttachedI2CParams(ps), pbus, ibus.fromSync, None)
+    I2C.attach(AttachedI2CParams(ps), pbus, ibus.fromAsync, None)
   }
   val i2cNodes = i2cs.map(_.ioNode.makeSink())
 }

--- a/src/main/scala/devices/pwm/PWM.scala
+++ b/src/main/scala/devices/pwm/PWM.scala
@@ -97,11 +97,13 @@ case class AttachedPWMParams(
   intXType: ClockCrossingType = NoCrossing)
 
 object PWM {
+  val nextId = { var i = -1; () => { i += 1; i} }
   def attach(params: AttachedPWMParams, controlBus: TLBusWrapper, intNode: IntInwardNode, mclock: Option[ModuleValue[Clock]])
-            (implicit p: Parameters, valName: ValName): TLPWM = {
+            (implicit p: Parameters): TLPWM = {
+    val name = s"pwm_${nextId()}"
     val pwm = LazyModule(new TLPWM(controlBus.beatBytes, params.pwm))
-
-    controlBus.coupleTo(s"slave_named_${valName.name}") {
+    pwm.suggestName(name)
+    controlBus.coupleTo(s"device_named_$name") {
       pwm.controlXing(params.controlXType) := TLFragmenter(controlBus.beatBytes, controlBus.blockBytes) := _
     }
     intNode := pwm.intXing(params.intXType)

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -10,7 +10,7 @@ case object PeripheryPWMKey extends Field[Seq[PWMParams]]
 
 trait HasPeripheryPWM { this: BaseSubsystem =>
   val pwms = p(PeripheryPWMKey).map { ps =>
-    PWM.attach(AttachedPWMParams(ps), pbus, ibus.fromSync, None)
+    PWM.attach(AttachedPWMParams(ps), pbus, ibus.fromAsync, None)
   }
   val pwmNodes = pwms.map(_.ioNode.makeSink())
 }

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -11,7 +11,7 @@ case object PeripherySPIKey extends Field[Seq[SPIParams]]
 trait HasPeripherySPI { this: BaseSubsystem =>
   val spiParams = p(PeripherySPIKey)  
   val spis = p(PeripherySPIKey).map { ps =>
-    SPI.attach(AttachedSPIParams(ps), pbus, ibus.fromSync, None)
+    SPI.attach(AttachedSPIParams(ps), pbus, ibus.fromAsync, None)
   }
   val spiNodes = spis.map(_.ioNode.makeSink())
 }
@@ -29,7 +29,7 @@ case object PeripherySPIFlashKey extends Field[Seq[SPIFlashParams]]
 
 trait HasPeripherySPIFlash { this: BaseSubsystem =>
   val qspis = p(PeripherySPIFlashKey).map { ps =>
-    SPI.attachFlash(AttachedSPIFlashParams(ps, fBufferDepth = 8), pbus, pbus, ibus.fromSync, None)
+    SPI.attachFlash(AttachedSPIFlashParams(ps, fBufferDepth = 8), pbus, pbus, ibus.fromAsync, None)
   }
   val qspiNodes = qspis.map(_.ioNode.makeSink())
 }

--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -135,11 +135,14 @@ case class AttachedUARTParams(
   intXType: ClockCrossingType = NoCrossing)
 
 object UART {
+  val nextId = { var i = -1; () => { i += 1; i} }
   def attach(params: AttachedUARTParams, controlBus: TLBusWrapper, intNode: IntInwardNode, mclock: Option[ModuleValue[Clock]])
-            (implicit p: Parameters, valName: ValName): TLUART = {
+            (implicit p: Parameters): TLUART = {
+    val name = s"uart_${nextId()}"
     val uart = LazyModule(new TLUART(controlBus.beatBytes, params.uart, params.divinit))
+    uart.suggestName(name)
 
-    controlBus.coupleTo(s"slave_named_${valName.name}") {
+    controlBus.coupleTo(s"slave_named_name") {
       uart.controlXing(params.controlXType) := TLFragmenter(controlBus.beatBytes, controlBus.blockBytes) := _
     }
     intNode := uart.intXing(params.intXType)

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -10,7 +10,7 @@ case object PeripheryUARTKey extends Field[Seq[UARTParams]]
 trait HasPeripheryUART { this: BaseSubsystem =>
   val uarts = p(PeripheryUARTKey).map { ps =>
     val divinit = (p(PeripheryBusKey).frequency / 115200).toInt
-    UART.attach(AttachedUARTParams(ps, divinit), pbus, ibus.fromSync, None)
+    UART.attach(AttachedUARTParams(ps, divinit), pbus, ibus.fromAsync, None)
   }
   val uartNodes = uarts.map(_.ioNode.makeSink())
 }


### PR DESCRIPTION
- Instead of being named based on chisel valNames, devices get a standardized name and share a global index
- legacy periphery traits use async interrupt crossings