### PR TITLE
devices: use XAttachParams, which anticipate IOOverlayParams

### DIFF
--- a/src/main/scala/devices/gpio/GPIOPeriphery.scala
+++ b/src/main/scala/devices/gpio/GPIOPeriphery.scala
@@ -8,10 +8,7 @@ import freechips.rocketchip.subsystem.BaseSubsystem
 case object PeripheryGPIOKey extends Field[Seq[GPIOParams]]
 
 trait HasPeripheryGPIO { this: BaseSubsystem =>
-  val gpios = p(PeripheryGPIOKey).map { ps =>
-    GPIO.attach(AttachedGPIOParams(ps), pbus, ibus.fromAsync, None)
-  }
-  val gpioNodes = gpios.map(_.ioNode.makeSink())
+  val gpioNodes = p(PeripheryGPIOKey).map { ps => GPIO.attach(GPIOAttachParams(ps, pbus, ibus.fromAsync)).ioNode.makeSink }
 }
 
 trait HasPeripheryGPIOBundle {

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -9,10 +9,9 @@ import freechips.rocketchip.subsystem.{BaseSubsystem}
 case object PeripheryI2CKey extends Field[Seq[I2CParams]]
 
 trait HasPeripheryI2C { this: BaseSubsystem =>
-  val i2cs =  p(PeripheryI2CKey).map { ps =>
-    I2C.attach(AttachedI2CParams(ps), pbus, ibus.fromAsync, None)
+  val i2cNodes =  p(PeripheryI2CKey).map { ps =>
+    I2C.attach(I2CAttachParams(ps, pbus, ibus.fromAsync)).ioNode.makeSink()
   }
-  val i2cNodes = i2cs.map(_.ioNode.makeSink())
 }
 
 trait HasPeripheryI2CBundle {

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -9,10 +9,7 @@ import freechips.rocketchip.subsystem.BaseSubsystem
 case object PeripheryPWMKey extends Field[Seq[PWMParams]]
 
 trait HasPeripheryPWM { this: BaseSubsystem =>
-  val pwms = p(PeripheryPWMKey).map { ps =>
-    PWM.attach(AttachedPWMParams(ps), pbus, ibus.fromAsync, None)
-  }
-  val pwmNodes = pwms.map(_.ioNode.makeSink())
+  val pwmNodes = p(PeripheryPWMKey).map { ps => PWM.attach(PWMAttachParams(ps, pbus, ibus.fromAsync)).ioNode.makeSink }
 }
 
 trait HasPeripheryPWMBundle {

--- a/src/main/scala/devices/spi/SPI.scala
+++ b/src/main/scala/devices/spi/SPI.scala
@@ -8,61 +8,89 @@ import freechips.rocketchip.interrupts._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
 
-case class AttachedSPIParams(
+case class SPIAttachParams(
   spi: SPIParams,
+  controlBus: TLBusWrapper,
+  intNode: IntInwardNode,
   controlXType: ClockCrossingType = NoCrossing,
-  intXType: ClockCrossingType = NoCrossing)
+  intXType: ClockCrossingType = NoCrossing,
+  mclock: Option[ModuleValue[Clock]] = None,
+  mreset: Option[ModuleValue[Bool]] = None)
+  (implicit val p: Parameters)
 
-case class AttachedSPIFlashParams(
-  qspi: SPIFlashParams,
+case class SPIFlashAttachParams(
+  spi: SPIFlashParams,
+  controlBus: TLBusWrapper,
+  memBus: TLBusWrapper,
+  intNode: IntInwardNode,
   fBufferDepth: Int = 0,
   controlXType: ClockCrossingType = NoCrossing,
   intXType: ClockCrossingType = NoCrossing,
-  memXType: ClockCrossingType = NoCrossing)
+  memXType: ClockCrossingType = NoCrossing,
+  mclock: Option[ModuleValue[Clock]] = None,
+  mreset: Option[ModuleValue[Bool]] = None)
+  (implicit val p: Parameters)
 
 object SPI {
   val nextId = { var i = -1; () => { i += 1; i} }
-  def attach(params: AttachedSPIParams, controlBus: TLBusWrapper, intNode: IntInwardNode, mclock: Option[ModuleValue[Clock]])
-            (implicit p: Parameters): TLSPI = {
+  def attach(params: SPIAttachParams): TLSPI = {
+    implicit val p = params.p
     val name = s"spi_${nextId()}"
-    val spi = LazyModule(new TLSPI(controlBus.beatBytes, params.spi))
+    val cbus = params.controlBus
+    val spi = LazyModule(new TLSPI(cbus.beatBytes, params.spi))
     spi.suggestName(name)
 
-    controlBus.coupleTo(s"device_named_$name") {
-      spi.controlXing(params.controlXType) := TLFragmenter(controlBus.beatBytes, controlBus.blockBytes) := _
+    cbus.coupleTo(s"device_named_$name") {
+      spi.controlXing(params.controlXType) := TLFragmenter(cbus.beatBytes, cbus.blockBytes) := _
     }
 
-    intNode := spi.intXing(params.intXType)
+    params.intNode := spi.intXing(params.intXType)
 
-    InModuleBody { spi.module.clock := mclock.map(_.getWrappedValue).getOrElse(controlBus.module.clock) }
+    InModuleBody { spi.module.clock := params.mclock.map(_.getWrappedValue).getOrElse(cbus.module.clock) }
+    InModuleBody { spi.module.reset := params.mreset.map(_.getWrappedValue).getOrElse(cbus.module.reset) }
 
     spi
   }
 
+  def attachAndMakePort(params: SPIAttachParams): ModuleValue[SPIPortIO] = {
+    val spi = attach(params)
+    val spiNode = spi.ioNode.makeSink()(params.p)
+    InModuleBody { spiNode.makeIO()(ValName(spi.name)) }
+  }
+
   val nextFlashId = { var i = -1; () => { i += 1; i} }
-  def attachFlash(params: AttachedSPIFlashParams, controlBus: TLBusWrapper, memBus: TLBusWrapper, intNode: IntInwardNode, mclock: Option[ModuleValue[Clock]])
-                 (implicit p: Parameters): TLSPIFlash = {
+  def attachFlash(params: SPIFlashAttachParams): TLSPIFlash = {
+    implicit val p = params.p
     val name = s"qspi_${nextFlashId()}" // TODO should these be shared with regular SPIs?
-    val qspi = LazyModule(new TLSPIFlash(controlBus.beatBytes, params.qspi))
+    val cbus = params.controlBus
+    val mbus = params.memBus
+    val qspi = LazyModule(new TLSPIFlash(cbus.beatBytes, params.spi))
     qspi.suggestName(name)
 
-    controlBus.coupleTo(s"device_named_$name") {
-      qspi.controlXing(params.controlXType) := TLFragmenter(controlBus.beatBytes, controlBus.blockBytes) := _
+    cbus.coupleTo(s"device_named_$name") {
+      qspi.controlXing(params.controlXType) := TLFragmenter(cbus.beatBytes, cbus.blockBytes) := _
     }
 
-    memBus.coupleTo(s"mem_named_$name") {
+    mbus.coupleTo(s"mem_named_$name") {
       (qspi.memXing(params.memXType)
-        := TLFragmenter(1, memBus.blockBytes)
+        := TLFragmenter(1, mbus.blockBytes)
         := TLBuffer(BufferParams(params.fBufferDepth), BufferParams.none)
-        := TLWidthWidget(memBus.beatBytes)
+        := TLWidthWidget(mbus.beatBytes)
         := _)
     }
 
-    intNode := qspi.intXing(params.intXType)
+    params.intNode := qspi.intXing(params.intXType)
 
-    InModuleBody { qspi.module.clock := mclock.map(_.getWrappedValue).getOrElse(controlBus.module.clock) }
+    InModuleBody { qspi.module.clock := params.mclock.map(_.getWrappedValue).getOrElse(cbus.module.clock) }
+    InModuleBody { qspi.module.reset := params.mreset.map(_.getWrappedValue).getOrElse(cbus.module.reset) }
 
     qspi
+  }
+
+  def attachAndMakePort(params: SPIFlashAttachParams): ModuleValue[SPIPortIO] = {
+    val qspi = attachFlash(params)
+    val qspiNode = qspi.ioNode.makeSink()(params.p)
+    InModuleBody { qspiNode.makeIO()(ValName(qspi.name)) }
   }
 
   def synchronize(q: SPIPortIO): SPIPortIO = {

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -9,11 +9,7 @@ import freechips.rocketchip.diplomacy._
 case object PeripherySPIKey extends Field[Seq[SPIParams]]
 
 trait HasPeripherySPI { this: BaseSubsystem =>
-  val spiParams = p(PeripherySPIKey)  
-  val spis = p(PeripherySPIKey).map { ps =>
-    SPI.attach(AttachedSPIParams(ps), pbus, ibus.fromAsync, None)
-  }
-  val spiNodes = spis.map(_.ioNode.makeSink())
+  val spiNodes = p(PeripherySPIKey).map { ps => SPI.attach(SPIAttachParams(ps, pbus, ibus.fromAsync)).ioNode.makeSink() }
 }
 
 trait HasPeripherySPIBundle {
@@ -28,10 +24,9 @@ trait HasPeripherySPIModuleImp extends LazyModuleImp with HasPeripherySPIBundle 
 case object PeripherySPIFlashKey extends Field[Seq[SPIFlashParams]]
 
 trait HasPeripherySPIFlash { this: BaseSubsystem =>
-  val qspis = p(PeripherySPIFlashKey).map { ps =>
-    SPI.attachFlash(AttachedSPIFlashParams(ps, fBufferDepth = 8), pbus, pbus, ibus.fromAsync, None)
+  val qspiNodes = p(PeripherySPIFlashKey).map { ps =>
+    SPI.attachFlash(SPIFlashAttachParams(ps, pbus, pbus, ibus.fromAsync, fBufferDepth = 8)).ioNode.makeSink()
   }
-  val qspiNodes = qspis.map(_.ioNode.makeSink())
 }
 
 trait HasPeripherySPIFlashBundle {

--- a/src/main/scala/devices/spi/TLSPI.scala
+++ b/src/main/scala/devices/spi/TLSPI.scala
@@ -42,9 +42,7 @@ case class SPIParams(
     frameBits: Int = 8,
     delayBits: Int = 8,
     divisorBits: Int = 12,
-    sampleDelay: Int = 2,
-    crossingType: ClockCrossingType = SynchronousCrossing()
-    )
+    sampleDelay: Int = 2)
   extends SPIParamsBase {
 
   require(frameBits >= 4)

--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -30,8 +30,7 @@ case class SPIFlashParams(
     csWidth: Int = 1,
     delayBits: Int = 8,
     divisorBits: Int = 12,
-    sampleDelay: Int = 2,
-    crossingType: ClockCrossingType = SynchronousCrossing())
+    sampleDelay: Int = 2)
   extends SPIFlashParamsBase {
   val frameBits = 8
   val insnAddrBytes = 4

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -8,11 +8,10 @@ import freechips.rocketchip.subsystem.{BaseSubsystem, PeripheryBusKey}
 case object PeripheryUARTKey extends Field[Seq[UARTParams]]
 
 trait HasPeripheryUART { this: BaseSubsystem =>
-  val uarts = p(PeripheryUARTKey).map { ps =>
+  val uartNodes = p(PeripheryUARTKey).map { ps =>
     val divinit = (p(PeripheryBusKey).frequency / 115200).toInt
-    UART.attach(AttachedUARTParams(ps, divinit), pbus, ibus.fromAsync, None)
+    UART.attach(UARTAttachParams(ps, divinit, pbus, ibus.fromAsync)).ioNode.makeSink
   }
-  val uartNodes = uarts.map(_.ioNode.makeSink())
 }
 
 trait HasPeripheryUARTBundle {


### PR DESCRIPTION
- In preparation for tighter integration with `Overlays` from `fpga-shells`, switches the helper object attach methods over to using a single case class to capture their attachment points. 
- Adds helpers for making IO ports at the call site. 
- Allows for override of controller `resets`