### PR TITLE
chiplink: find error devices per opcode

### DIFF
--- a/src/main/scala/devices/chiplink/Parameters.scala
+++ b/src/main/scala/devices/chiplink/Parameters.scala
@@ -5,7 +5,7 @@ import Chisel._
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util.AsyncQueueParams
+import freechips.rocketchip.util.{AsyncQueueParams, MuxLiteral}
 
 case class ChipLinkParams(TLUH: Seq[AddressSet], TLC: Seq[AddressSet], sourceBits: Int = 6, sinkBits: Int = 5, syncTX: Boolean = false, fpgaReset: Boolean = false)
 {
@@ -39,7 +39,7 @@ case class ChipLinkParams(TLUH: Seq[AddressSet], TLC: Seq[AddressSet], sourceBit
 case object ChipLinkKey extends Field[Seq[ChipLinkParams]]
 
 case class TXN(domain: Int, source: Int)
-case class ChipLinkInfo(params: ChipLinkParams, edgeIn: TLEdge, edgeOut: TLEdge, errorDev: BigInt)
+case class ChipLinkInfo(params: ChipLinkParams, edgeIn: TLEdge, edgeOut: TLEdge, error: Seq[(UInt,UInt)])
 {
   // TL source => CL TXN
   val sourceMap: Map[Int, TXN] = {
@@ -131,8 +131,10 @@ case class ChipLinkInfo(params: ChipLinkParams, edgeIn: TLEdge, edgeOut: TLEdge,
   }
 
   // You can't just unilaterally use error, because this would misalign the mask
-  def makeError(legal: Bool, address: UInt): UInt =
+  def makeError(legal: Bool, in_addr: UInt, opcode: UInt): UInt = {
+    val out_addr = MuxLiteral(Cat(legal, opcode), in_addr, error)
     Cat(
-      Mux(legal, address, UInt(errorDev))(params.addressBits-1, log2Ceil(params.maxXfer)),
-      address(log2Ceil(params.maxXfer)-1, 0))
+      out_addr(params.addressBits-1, log2Ceil(params.maxXfer)),
+      in_addr(log2Ceil(params.maxXfer)-1, 0))
+  }
 }

--- a/src/main/scala/devices/chiplink/SourceA.scala
+++ b/src/main/scala/devices/chiplink/SourceA.scala
@@ -80,7 +80,7 @@ class SourceA(info: ChipLinkInfo) extends Module
   a.bits.param   := q_param
   a.bits.size    := q_size
   a.bits.source  := Cat(q_domain, source)
-  a.bits.address := info.makeError(q_legal, q_address)
+  a.bits.address := info.makeError(q_legal, q_address, q_opcode)
   a.bits.mask    := MaskGen(q_address0, q_size, info.params.dataBytes)
   a.bits.data    := io.q.bits
   a.bits.corrupt := Bool(false)

--- a/src/main/scala/devices/chiplink/SourceC.scala
+++ b/src/main/scala/devices/chiplink/SourceC.scala
@@ -70,7 +70,7 @@ class SourceC(info: ChipLinkInfo) extends Module
   io.c.bits.param   := q_param
   io.c.bits.size    := q_size
   io.c.bits.source  := Mux(q_release, source, UInt(0)) // always domain 0
-  io.c.bits.address := info.makeError(q_legal, q_address)
+  io.c.bits.address := info.makeError(q_legal, q_address, q_opcode)
   io.c.bits.data    := io.q.bits
   io.c.bits.corrupt := Bool(false)
 


### PR DESCRIPTION
Enable chiplink to route messages to multiple error devices if each is providing a capability to respond to a different type of request.