### PR TITLE
subsystem: sbus.control_bus => cbus

### DIFF
--- a/src/main/scala/devices/mockaon/MockAONPeriphery.scala
+++ b/src/main/scala/devices/mockaon/MockAONPeriphery.scala
@@ -18,7 +18,7 @@ trait HasPeripheryMockAON extends CanHavePeripheryCLINT with HasPeripheryDebug {
   // are in the proper clock domain.
   val mockAONParams= p(PeripheryMockAONKey)
   val aon = LazyModule(new MockAONWrapper(cbus.beatBytes, mockAONParams))
-  aon.node := cbus.coupleTo("aon") { TLAsyncCrossingSource() := TLFragmenter(cbus.beatBytes, cbus.blockBytes) := _ }
+  aon.node := cbus.coupleTo("aon") { TLAsyncCrossingSource() := TLFragmenter(cbus) := _ }
   ibus.fromSync := IntSyncCrossingSink() := aon.intnode
 }
 

--- a/src/main/scala/devices/mockaon/MockAONPeriphery.scala
+++ b/src/main/scala/devices/mockaon/MockAONPeriphery.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.devices.tilelink.CanHavePeripheryCLINT
 import freechips.rocketchip.diplomacy.{LazyModule, LazyModuleImp}
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.subsystem.BaseSubsystem
-import freechips.rocketchip.tilelink.{TLAsyncCrossingSource}
+import freechips.rocketchip.tilelink.{TLAsyncCrossingSource, TLFragmenter}
 import freechips.rocketchip.util.{ResetCatchAndSync, SynchronizerShiftReg}
 
 case object PeripheryMockAONKey extends Field[MockAONParams]
@@ -17,8 +17,8 @@ trait HasPeripheryMockAON extends CanHavePeripheryCLINT with HasPeripheryDebug {
   // We override the clock & Reset here so that all synchronizers, etc
   // are in the proper clock domain.
   val mockAONParams= p(PeripheryMockAONKey)
-  val aon = LazyModule(new MockAONWrapper(sbus.control_bus.beatBytes, mockAONParams))
-  sbus.control_bus.toVariableWidthSlave(Some("aon")) { aon.node := TLAsyncCrossingSource() }
+  val aon = LazyModule(new MockAONWrapper(cbus.beatBytes, mockAONParams))
+  aon.node := cbus.coupleTo("aon") { TLAsyncCrossingSource() := TLFragmenter(cbus.beatBytes, cbus.blockBytes) := _ }
   ibus.fromSync := IntSyncCrossingSink() := aon.intnode
 }
 


### PR DESCRIPTION
- Moved sbus.control_bus to subsystem level
- Renamed it to cbus
- Depend less on the tilelink.CanAttachTLSlaves API