### PR TITLE
Correct name of rxen field

### DIFF
--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -105,7 +105,7 @@ abstract class UART(busWidthBytes: Int, val c: UARTParams, divisorInit: Int = 0)
       RegField(stopCountBits, nstop,
                RegFieldDesc("nstop","Number of stop bits", reset=Some(0))))),
     UARTCtrlRegs.rxctrl -> Seq(RegField(1, rxen,
-               RegFieldDesc("txen","Receive enable", reset=Some(0)))),
+               RegFieldDesc("rxen","Receive enable", reset=Some(0)))),
     UARTCtrlRegs.txmark -> Seq(RegField(txCountBits, txwm,
                RegFieldDesc("txcnt","Transmit watermark level", reset=Some(0)))),
     UARTCtrlRegs.rxmark -> Seq(RegField(rxCountBits, rxwm,


### PR DESCRIPTION
The rxen register in the UART had "txen" erroneously set as its field name in the RegFieldDesc constructor.

This resulted in the incorrectly-named rxen register showing up as txen, and thus replacing the correct txen field in the JSON output from the Rocket/Chisel flow.