### PR TITLE
Move UART rxmark register to 4-byte aligned address

### DIFF
--- a/src/main/scala/devices/uart/UARTCtrlRegs.scala
+++ b/src/main/scala/devices/uart/UARTCtrlRegs.scala
@@ -7,7 +7,7 @@ object UARTCtrlRegs {
   val txctrl = 0x08
   val txmark = 0x0a
   val rxctrl = 0x0c
-  val rxmark = 0x0e
+  val rxmark = 0x1c
 
   val ie     = 0x10
   val ip     = 0x14


### PR DESCRIPTION
The address of the rxmark register was not 4-byte aligned, which seems to be at odds with every other register in the Rocket peripherals.

We're generating our register access macros from the JSON output, assuming all registers are 4-byte aligned, and accesses to this were triggering unaligned access exceptions (interestingly, though, only when -O0 was being passed to the compiler, when being optimized, the compiler would emit a half-word access for this register, still it's not great to rely on that).

If you aren't auto-generating your register access paraphernalia then some magic numbers might need to be updated along with this change, but I don't think they're in this repo, right?