### PR TITLE
Improve SPI flash ffmt register layout and fix some field names

### DIFF
--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -50,6 +50,7 @@ class SPIFlashTopModule(c: SPIFlashParamsBase, outer: TLSPIFlashBase)
 
   val flash = Module(new SPIFlashMap(c))
   val arb = Module(new SPIArbiter(c, 2))
+  val reserved = Reg(init = UInt(0,width = 2))
 
   private val (f, _) = outer.fnode.in(0)
   // Tie unused channels
@@ -84,24 +85,25 @@ class SPIFlashTopModule(c: SPIFlashParamsBase, outer: TLSPIFlashBase)
   protected val regmapFlash = Seq(
     SPICRs.insnmode -> Seq(RegField(1, flash_en,
                            RegFieldDesc("flash_en","SPIFlash mode select", reset=Some(1)))),
-    SPICRs.insnfmt -> RegFieldGroup("ffmtlen",Some("SPIFlash instruction length"),Seq(
+    SPICRs.insnfmt -> RegFieldGroup("ffmt",Some("SPIFlash instruction length"),Seq(
       RegField(1, insn.cmd.en,
                RegFieldDesc("cmd_en","Enable sending of command", reset=Some(1))),
       RegField(c.insnAddrLenBits, insn.addr.len,
-               RegFieldDesc("cmd_en","Number of address bytes", reset=Some(3))),
+               RegFieldDesc("addr_len","Number of address bytes", reset=Some(3))),
       RegField(c.insnPadLenBits, insn.pad.cnt,
-               RegFieldDesc("cmd_en","Number of dummy cycles", reset=Some(0))))),
-    SPICRs.insnproto -> RegFieldGroup("ffmtproto",Some("SPIFlash instruction format"),Seq(
+               RegFieldDesc("pad_cnt","Number of dummy cycles", reset=Some(0))),
       RegField(SPIProtocol.width, insn.cmd.proto,
                RegFieldDesc("cmd_proto","Protocol for transmitting command", reset=Some(0))),
       RegField(SPIProtocol.width, insn.addr.proto,
                RegFieldDesc("addr_proto","Protocol for transmitting address and padding", reset=Some(0))),
       RegField(SPIProtocol.width, insn.data.proto,
-               RegFieldDesc("data_proto","Protocol for transmitting receiving data", reset=Some(0))))),
-    SPICRs.insncmd -> Seq(RegField(c.insnCmdBits, insn.cmd.code,
-                          RegFieldDesc("cmd_code","Value of command byte", reset=Some(3)))),
-    SPICRs.insnpad -> Seq(RegField(c.frameBits, insn.pad.code,
-                          RegFieldDesc("pad_code","First 8 bits to transmit during dummy cycles", reset=Some(0)))))
+               RegFieldDesc("data_proto","Protocol for transmitting receiving data", reset=Some(0))),
+      RegField.r(2,reserved,
+               RegFieldDesc("reserved","reserved", reset=Some(0))),
+      RegField(c.insnCmdBits, insn.cmd.code,
+               RegFieldDesc("cmd_code","Value of command byte", reset=Some(3))),
+      RegField(c.frameBits, insn.pad.code,
+               RegFieldDesc("pad_code","First 8 bits to transmit during dummy cycles", reset=Some(0))))))
 }
 
 abstract class TLSPIFlashBase(w: Int, c: SPIFlashParamsBase)(implicit p: Parameters) extends TLSPIBase(w,c)(p) {


### PR DESCRIPTION
The SPI flash instruction format register `ffmt` had a couple of issues.

1. The register was split into multiple RegFieldGroups which is unnecessary, and resulted in some fields being given a non-32-bit aligned address in the generated registers JSON. It makes more sense to combine as a single 32-bit register with all of the fields contained within that and with names which more consistently match the documentation (section 18.16 of the SiFive FE310-G000 Manual v2p3 I'm looking at).

2. The fields for addr_len and pad_len were erroneously named cmd_len in their RegField() definitions.