### PR TITLE
[WIP] SPI/UART RegField Desc Cleanup

### DIFF
--- a/src/main/scala/devices/spi/TLSPI.scala
+++ b/src/main/scala/devices/spi/TLSPI.scala
@@ -79,26 +79,26 @@ class SPITopModule(c: SPIParamsBase, outer: TLSPIBase)
 
   protected val regmapBase = Seq(
     SPICRs.sckdiv -> Seq(RegField(c.divisorBits, ctrl.sck.div,
-                         RegFieldDesc("sckdiv","Serial clock divisor", reset=Some(3)))),
-    SPICRs.sckmode ->  RegFieldGroup("sckmode",Some("Serial clock mode"),Seq(
+                         RegFieldDesc("sckdiv", "Serial clock divisor", reset=Some(3)))),
+    SPICRs.sckmode ->  RegFieldGroup("sckmode", Some("Serial clock mode"), Seq(
       RegField(1, ctrl.sck.pha,
-               RegFieldDesc("sckmode_pha","Serial clock phase", reset=Some(0))),
+               RegFieldDesc("sckmode_pha", "Serial clock phase", reset=Some(0))),
       RegField(1, ctrl.sck.pol,
-               RegFieldDesc("sckmode_pol","Serial clock polarity", reset=Some(0))))),
+               RegFieldDesc("sckmode_pol", "Serial clock polarity", reset=Some(0))))),
     SPICRs.csid -> Seq(RegField(c.csIdBits, ctrl.cs.id,
-                       RegFieldDesc("csid","Chip select id", reset=Some(0)))),
+                       RegFieldDesc("csid", "Chip select id", reset=Some(0)))),
     SPICRs.csdef -> ctrl.cs.dflt.map(x => RegField(1, x,
-                    RegFieldDesc("csdef","Chip select default", reset=Some(1)))),
+                    RegFieldDesc("csdef", "Chip select default", reset=Some(1)))),
     SPICRs.csmode -> Seq(RegField(SPICSMode.width, ctrl.cs.mode,
-                         RegFieldDesc("csmode","Chip select mode", reset=Some(SPICSMode.Auto.litValue())))),
+                         RegFieldDesc("csmode", "Chip select mode", reset=Some(SPICSMode.Auto.litValue())))),
     SPICRs.dcssck -> Seq(RegField(c.delayBits, ctrl.dla.cssck,
-                         RegFieldDesc("cssck","CS to SCK delay", reset=Some(1)))),
+                         RegFieldDesc("cssck", "CS to SCK delay", reset=Some(1)))),
     SPICRs.dsckcs -> Seq(RegField(c.delayBits, ctrl.dla.sckcs,
-                         RegFieldDesc("sckcs","SCK to CS delay", reset=Some(1)))),
+                         RegFieldDesc("sckcs", "SCK to CS delay", reset=Some(1)))),
     SPICRs.dintercs -> Seq(RegField(c.delayBits, ctrl.dla.intercs,
-                           RegFieldDesc("intercs","Minimum CS inactive time", reset=Some(1)))),
+                           RegFieldDesc("intercs", "Minimum CS inactive time", reset=Some(1)))),
     SPICRs.dinterxfr -> Seq(RegField(c.delayBits, ctrl.dla.interxfr,
-                            RegFieldDesc("interxfr","Minimum interframe delay", reset=Some(0)))),
+                            RegFieldDesc("interxfr", "Minimum interframe delay", reset=Some(0)))),
 
     SPICRs.fmt -> RegFieldGroup("fmt",Some("Serial frame format"),Seq(
       RegField(SPIProtocol.width, ctrl.fmt.proto,

--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -50,6 +50,7 @@ class SPIFlashTopModule(c: SPIFlashParamsBase, outer: TLSPIFlashBase)
 
   val flash = Module(new SPIFlashMap(c))
   val arb = Module(new SPIArbiter(c, 2))
+  val reserved = Reg(init = UInt(0,width = 2))
 
   private val (f, _) = outer.fnode.in(0)
   // Tie unused channels
@@ -84,24 +85,25 @@ class SPIFlashTopModule(c: SPIFlashParamsBase, outer: TLSPIFlashBase)
   protected val regmapFlash = Seq(
     SPICRs.insnmode -> Seq(RegField(1, flash_en,
                            RegFieldDesc("flash_en","SPIFlash mode select", reset=Some(1)))),
-    SPICRs.insnfmt -> RegFieldGroup("ffmtlen",Some("SPIFlash instruction length"),Seq(
+    SPICRs.insnfmt -> RegFieldGroup("ffmt",Some("SPIFlash instruction length"),Seq(
       RegField(1, insn.cmd.en,
                RegFieldDesc("cmd_en","Enable sending of command", reset=Some(1))),
       RegField(c.insnAddrLenBits, insn.addr.len,
-               RegFieldDesc("cmd_en","Number of address bytes", reset=Some(3))),
+               RegFieldDesc("addr_len","Number of address bytes", reset=Some(3))),
       RegField(c.insnPadLenBits, insn.pad.cnt,
-               RegFieldDesc("cmd_en","Number of dummy cycles", reset=Some(0))))),
-    SPICRs.insnproto -> RegFieldGroup("ffmtproto",Some("SPIFlash instruction format"),Seq(
+               RegFieldDesc("pad_cnt","Number of dummy cycles", reset=Some(0))),
       RegField(SPIProtocol.width, insn.cmd.proto,
                RegFieldDesc("cmd_proto","Protocol for transmitting command", reset=Some(0))),
       RegField(SPIProtocol.width, insn.addr.proto,
                RegFieldDesc("addr_proto","Protocol for transmitting address and padding", reset=Some(0))),
       RegField(SPIProtocol.width, insn.data.proto,
-               RegFieldDesc("data_proto","Protocol for transmitting receiving data", reset=Some(0))))),
-    SPICRs.insncmd -> Seq(RegField(c.insnCmdBits, insn.cmd.code,
-                          RegFieldDesc("cmd_code","Value of command byte", reset=Some(3)))),
-    SPICRs.insnpad -> Seq(RegField(c.frameBits, insn.pad.code,
-                          RegFieldDesc("pad_code","First 8 bits to transmit during dummy cycles", reset=Some(0)))))
+               RegFieldDesc("data_proto","Protocol for transmitting receiving data", reset=Some(0))),
+      RegField.r(2,reserved,
+               RegFieldDesc("reserved","reserved", reset=Some(0))),
+      RegField(c.insnCmdBits, insn.cmd.code,
+               RegFieldDesc("cmd_code","Value of command byte", reset=Some(3))),
+      RegField(c.frameBits, insn.pad.code,
+               RegFieldDesc("pad_code","First 8 bits to transmit during dummy cycles", reset=Some(0))))))
 }
 
 abstract class TLSPIFlashBase(w: Int, c: SPIFlashParamsBase)(implicit p: Parameters) extends TLSPIBase(w,c)(p) {

--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -83,25 +83,25 @@ class SPIFlashTopModule(c: SPIFlashParamsBase, outer: TLSPIFlashBase)
 
   protected val regmapFlash = Seq(
     SPICRs.insnmode -> Seq(RegField(1, flash_en,
-                           RegFieldDesc("flash_en","SPIFlash mode select", reset=Some(1)))),
-    SPICRs.insnfmt -> RegFieldGroup("ffmt",Some("SPIFlash instruction length"),Seq(
+                           RegFieldDesc("flash_en", "SPIFlash mode select", reset=Some(1)))),
+    SPICRs.insnfmt -> RegFieldGroup("ffmt", Some("SPIFlash read instruction format"), Seq(
       RegField(1, insn.cmd.en,
-               RegFieldDesc("cmd_en","Enable sending of command", reset=Some(1))),
+               RegFieldDesc("cmd_en", "Enable sending of command", reset=Some(1))),
       RegField(c.insnAddrLenBits, insn.addr.len,
-               RegFieldDesc("addr_len","Number of address bytes", reset=Some(3))),
+               RegFieldDesc("addr_len", "Number of address bytes", reset=Some(3))),
       RegField(c.insnPadLenBits, insn.pad.cnt,
-               RegFieldDesc("pad_cnt","Number of dummy cycles", reset=Some(0))),
+               RegFieldDesc("pad_cnt", "Number of dummy cycles", reset=Some(0))),
       RegField(SPIProtocol.width, insn.cmd.proto,
-               RegFieldDesc("cmd_proto","Protocol for transmitting command", reset=Some(0))),
+               RegFieldDesc("cmd_proto", "Protocol for transmitting command", reset=Some(0))),
       RegField(SPIProtocol.width, insn.addr.proto,
-               RegFieldDesc("addr_proto","Protocol for transmitting address and padding", reset=Some(0))),
+               RegFieldDesc("addr_proto", "Protocol for transmitting address and padding", reset=Some(0))),
       RegField(SPIProtocol.width, insn.data.proto,
-               RegFieldDesc("data_proto","Protocol for transmitting receiving data", reset=Some(0))),
+               RegFieldDesc("data_proto", "Protocol for transmitting receiving data", reset=Some(0))),
       RegField(2),
       RegField(c.insnCmdBits, insn.cmd.code,
-               RegFieldDesc("cmd_code","Value of command byte", reset=Some(3))),
+               RegFieldDesc("cmd_code", "Value of command byte", reset=Some(3))),
       RegField(c.frameBits, insn.pad.code,
-               RegFieldDesc("pad_code","First 8 bits to transmit during dummy cycles", reset=Some(0))))))
+               RegFieldDesc("pad_code", "First 8 bits to transmit during dummy cycles", reset=Some(0))))))
 }
 
 abstract class TLSPIFlashBase(w: Int, c: SPIFlashParamsBase)(implicit p: Parameters) extends TLSPIBase(w,c)(p) {

--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -84,24 +84,30 @@ class SPIFlashTopModule(c: SPIFlashParamsBase, outer: TLSPIFlashBase)
   protected val regmapFlash = Seq(
     SPICRs.insnmode -> Seq(RegField(1, flash_en,
                            RegFieldDesc("flash_en", "SPIFlash mode select", reset=Some(1)))),
+    // Note that these are all in the 'ffmt' group, but are defined with seperate calls
+    // because the addresses are actually byte addresses. This makes it easy to align
+    // them to byte boundaries without explicitly having to add padding.
     SPICRs.insnfmt -> RegFieldGroup("ffmt", Some("SPIFlash read instruction format"), Seq(
       RegField(1, insn.cmd.en,
-               RegFieldDesc("cmd_en", "Enable sending of command", reset=Some(1))),
+        RegFieldDesc("cmd_en", "Enable sending of command", reset=Some(1))),
       RegField(c.insnAddrLenBits, insn.addr.len,
-               RegFieldDesc("addr_len", "Number of address bytes", reset=Some(3))),
+        RegFieldDesc("addr_len", "Number of address bytes", reset=Some(3))),
       RegField(c.insnPadLenBits, insn.pad.cnt,
-               RegFieldDesc("pad_cnt", "Number of dummy cycles", reset=Some(0))),
+        RegFieldDesc("pad_cnt", "Number of dummy cycles", reset=Some(0))))),
+    SPICRs.insnproto -> RegFieldGroup("ffmt", None, Seq(
       RegField(SPIProtocol.width, insn.cmd.proto,
-               RegFieldDesc("cmd_proto", "Protocol for transmitting command", reset=Some(0))),
+        RegFieldDesc("cmd_proto", "Protocol for transmitting command", reset=Some(0))),
       RegField(SPIProtocol.width, insn.addr.proto,
-               RegFieldDesc("addr_proto", "Protocol for transmitting address and padding", reset=Some(0))),
+        RegFieldDesc("addr_proto", "Protocol for transmitting address and padding", reset=Some(0))),
       RegField(SPIProtocol.width, insn.data.proto,
-               RegFieldDesc("data_proto", "Protocol for transmitting receiving data", reset=Some(0))),
-      RegField(2),
+        RegFieldDesc("data_proto", "Protocol for transmitting receiving data", reset=Some(0))))),
+    SPICRs.insncmd -> RegFieldGroup("ffmt", None, Seq(
       RegField(c.insnCmdBits, insn.cmd.code,
-               RegFieldDesc("cmd_code", "Value of command byte", reset=Some(3))),
+        RegFieldDesc("cmd_code", "Value of command byte", reset=Some(3))))),
+    SPICRs.insnpad -> RegFieldGroup("ffmt", None, Seq(
       RegField(c.frameBits, insn.pad.code,
-               RegFieldDesc("pad_code", "First 8 bits to transmit during dummy cycles", reset=Some(0))))))
+        RegFieldDesc("pad_code", "First 8 bits to transmit during dummy cycles", reset=Some(0)))))
+  )
 }
 
 abstract class TLSPIFlashBase(w: Int, c: SPIFlashParamsBase)(implicit p: Parameters) extends TLSPIBase(w,c)(p) {

--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -50,7 +50,6 @@ class SPIFlashTopModule(c: SPIFlashParamsBase, outer: TLSPIFlashBase)
 
   val flash = Module(new SPIFlashMap(c))
   val arb = Module(new SPIArbiter(c, 2))
-  val reserved = Reg(init = UInt(0,width = 2))
 
   private val (f, _) = outer.fnode.in(0)
   // Tie unused channels
@@ -98,8 +97,7 @@ class SPIFlashTopModule(c: SPIFlashParamsBase, outer: TLSPIFlashBase)
                RegFieldDesc("addr_proto","Protocol for transmitting address and padding", reset=Some(0))),
       RegField(SPIProtocol.width, insn.data.proto,
                RegFieldDesc("data_proto","Protocol for transmitting receiving data", reset=Some(0))),
-      RegField.r(2,reserved,
-               RegFieldDesc("reserved","reserved", reset=Some(0))),
+      RegField(2),
       RegField(c.insnCmdBits, insn.cmd.code,
                RegFieldDesc("cmd_code","Value of command byte", reset=Some(3))),
       RegField(c.frameBits, insn.pad.code,

--- a/src/main/scala/util/RegMapFIFO.scala
+++ b/src/main/scala/util/RegMapFIFO.scala
@@ -18,14 +18,14 @@ object NonBlockingEnqueue {
           enq.valid := valid && !quash
           enq.bits := data
           Bool(true)
-        }), RegFieldDesc("data","Transmit data")),
+        }), RegFieldDesc("data", "Transmit data", access=RegFieldAccessType.W)),
       RegField(regWidth - enqWidth - 1),
       RegField(1,
         !enq.ready,
         RegWriteFn((valid, data) =>  {
           quash := valid && data(0)
           Bool(true)
-        }), RegFieldDesc("full","Transmit FIFO full", volatile=true)))
+        }), RegFieldDesc("full", "Transmit FIFO full", access=RegFieldAccessType.R, volatile=true)))
   }
 }
 
@@ -40,9 +40,9 @@ object NonBlockingDequeue {
         RegReadFn(ready => {
           deq.ready := ready
           (Bool(true), deq.bits)
-        }), RegFieldDesc("data","Receive data", volatile=true)),
+        }), RegFieldDesc("data", "Receive data", volatile=true)),
       RegField(regWidth - deqWidth - 1),
       RegField.r(1, !deq.valid,
-                 RegFieldDesc("empty","Receive FIFO empty", volatile=true)))
+                 RegFieldDesc("empty", "Receive FIFO empty", volatile=true)))
   }
 }


### PR DESCRIPTION
Additional changes on top of #102 , this also adds some descriptions to the FIFO register fields used (currently) by SPI and UART.

As I was making this change, I realized that we need to be careful about assuming/hard-coding the SPI reg field widths, so that needs to be resolved before merging this change. I think the right thing to do is add `require`s on the current widths, dynamically add padding if necessary, or revert the change which merged these into one `RegFieldGroup`... they can all be in the same group even if they are different byte offsets, as in, they can be annotated with the same `RegFieldGroup` with different calls to `RegFieldGroup`. Will try that out shortly.