### PR TITLE
Stream: Clean up register descriptions and groupings

### DIFF
--- a/src/main/scala/devices/chiplink/Parameters.scala
+++ b/src/main/scala/devices/chiplink/Parameters.scala
@@ -36,7 +36,7 @@ case class ChipLinkParams(TLUH: Seq[AddressSet], TLC: Seq[AddressSet], sourceBit
 
 }
 
-case object ChipLinkKey extends Field[Seq[ChipLinkParams]]
+case object ChipLinkKey extends Field[Seq[ChipLinkParams]](Nil)
 
 case class TXN(domain: Int, source: Int)
 case class ChipLinkInfo(params: ChipLinkParams, edgeIn: TLEdge, edgeOut: TLEdge, errorDev: AddressSet)

--- a/src/main/scala/devices/stream/PseudoStream.scala
+++ b/src/main/scala/devices/stream/PseudoStream.scala
@@ -35,21 +35,30 @@ abstract class PseudoStream(busWidthBytes: Int, val params: PseudoStreamParams)(
       new PseudoStreamPortIO(params)) {
   lazy val module = new LazyModuleImp(this) {
 
-  val nbports = Wire(Vec(params.nChannels, new PseudoStreamChannelIO(params)))
-  val bports = Wire(Vec(params.nChannels, new PseudoStreamChannelIO(params)))
+    val nbports = Wire(Vec(params.nChannels, new PseudoStreamChannelIO(params)))
+    val bports = Wire(Vec(params.nChannels, new PseudoStreamChannelIO(params)))
 
-  regmap(
-    List.tabulate(params.nChannels)(idx => List(
-      PseudoStreamCtrlRegs.txfifo + 4096 * idx -> NonBlockingEnqueue(nbports(idx).txq, 64),
-      PseudoStreamCtrlRegs.rxfifo + 4096 * idx -> NonBlockingDequeue(nbports(idx).rxq, 64),
-      PseudoStreamCtrlRegs.txfifob + 4096 * idx -> Seq(
-        RegField.w(params.dataBits, bports(idx).txq, RegFieldDesc("txfifob", "blocking txfifo interface"))),
-      PseudoStreamCtrlRegs.rxfifob + 4096 * idx -> Seq(
-        RegField.r(params.dataBits, bports(idx).rxq, RegFieldDesc("rxfifob", "blocking rxfifo interface")))
-    )).flatten:_*)
+    regmap(
+      List.tabulate(params.nChannels)(idx => List(
+        (PseudoStreamCtrlRegs.txfifo + 4096 * idx -> RegFieldGroup(
+          s"txfifo${idx}",
+          Some(s"Non-Blocking Transmit FIFO for Channel ${idx}"),
+          NonBlockingEnqueue(nbports(idx).txq, 64))),
+        (PseudoStreamCtrlRegs.rxfifo + 4096 * idx -> RegFieldGroup(
+          s"rxfifo${idx}", Some(s"Non-Blocking Receive FIFO for Channel ${idx}"),
+          NonBlockingDequeue(nbports(idx).rxq, 64))),
+        (PseudoStreamCtrlRegs.txfifob + 4096 * idx -> RegFieldGroup(
+          s"txfifob${idx}", Some(s"Blocking Transmit FIFO for Channel ${idx}"),
+          Seq( RegField.w(params.dataBits, bports(idx).txq,
+            RegFieldDesc("data", s"Blocking Transmit data"))))),
+        (PseudoStreamCtrlRegs.rxfifob + 4096 * idx -> RegFieldGroup(
+          s"rxfifob${idx}", Some(s"Blocking Receive FIFO for Channel ${idx}"),
+          Seq(RegField.r(params.dataBits, bports(idx).rxq,
+            RegFieldDesc("data", s"Blocking Receive data", volatile=true)))))
+      )).flatten:_*)
 
-  (nbports zip bports).zipWithIndex.map { case ((nb, b), idx) =>
-    val txq_arb = Module(new Arbiter(UInt(width = params.dataBits), 2))
+    (nbports zip bports).zipWithIndex.map { case ((nb, b), idx) =>
+      val txq_arb = Module(new Arbiter(UInt(width = params.dataBits), 2))
     txq_arb.io.in(0) <> nb.txq
     txq_arb.io.in(1) <> b.txq
     port.channel(idx).txq <> txq_arb.io.out


### PR DESCRIPTION
I made the stream device register descriptions a little more organized by putting them into groups and adding the channel number to the register names to avoid multiple registers in the same device with the same name.

There should be no functional changes. 

The change also fixed some inconsistent indentation which is why it looks bigger than it is.