### PR TITLE
Allow optional bus blockers to be inserted while attaching devices

### DIFF
--- a/src/main/scala/devices/stream/PseudoStream.scala
+++ b/src/main/scala/devices/stream/PseudoStream.scala
@@ -6,7 +6,7 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
-import sifive.blocks.util.{NonBlockingEnqueue, NonBlockingDequeue}
+import sifive.blocks.util.{BasicBusBlocker, NonBlockingEnqueue, NonBlockingDequeue}
 
 case class PseudoStreamParams(
     address: BigInt,
@@ -68,6 +68,7 @@ class TLPseudoStream(busWidthBytes: Int, params: PseudoStreamParams)(implicit p:
 case class PseudoStreamAttachParams(
   stream: PseudoStreamParams,
   controlBus: TLBusWrapper,
+  blockerAddr: Option[BigInt] = None,
   controlXType: ClockCrossingType = NoCrossing,
   mclock: Option[ModuleValue[Clock]] = None,
   mreset: Option[ModuleValue[Bool]] = None)
@@ -83,10 +84,12 @@ object PseudoStream {
     val stream = LazyModule(new TLPseudoStream(cbus.beatBytes, params.stream))
     stream.suggestName(name)
 
-    cbus.coupleTo(s"slave_named_$name") {
+    cbus.coupleTo(s"device_named_$name") { bus =>
+      val blockerNode = params.blockerAddr.map(BasicBusBlocker(_, cbus, cbus.beatBytes, name))
       (stream.controlXing(params.controlXType)
         := TLFragmenter(cbus.beatBytes, cbus.blockBytes)
-        := TLBuffer(BufferParams.flow) := _)
+        := TLBuffer(BufferParams.flow)
+        := blockerNode.map { _ := bus } .getOrElse { bus })
     }
     InModuleBody { stream.module.clock := params.mclock.map(_.getWrappedValue).getOrElse(cbus.module.clock) }
     InModuleBody { stream.module.reset := params.mreset.map(_.getWrappedValue).getOrElse(cbus.module.reset) }

--- a/src/main/scala/devices/stream/PseudoStream.scala
+++ b/src/main/scala/devices/stream/PseudoStream.scala
@@ -88,7 +88,6 @@ object PseudoStream {
       val blockerNode = params.blockerAddr.map(BasicBusBlocker(_, cbus, cbus.beatBytes, name))
       (stream.controlXing(params.controlXType)
         := TLFragmenter(cbus.beatBytes, cbus.blockBytes)
-        := TLBuffer(BufferParams.flow)
         := blockerNode.map { _ := bus } .getOrElse { bus })
     }
     InModuleBody { stream.module.clock := params.mclock.map(_.getWrappedValue).getOrElse(cbus.module.clock) }

--- a/src/main/scala/util/BusBlocker.scala
+++ b/src/main/scala/util/BusBlocker.scala
@@ -1,0 +1,20 @@
+// See LICENSE for license details.
+package sifive.blocks.util
+
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.devices.tilelink._
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
+
+object BasicBusBlocker {
+  def apply(addr: BigInt, cbus: TLBusWrapper, beatBytes: Int, name: String)(implicit p: Parameters): TLNode = {
+    val bus_blocker = LazyModule(new BasicBusBlocker(BasicBusBlockerParams(
+      controlAddress = addr,
+      controlBeatBytes = cbus.beatBytes,
+      deviceBeatBytes = beatBytes)))
+
+    cbus.coupleTo(s"bus_blocker_$name") { bus_blocker.controlNode := TLFragmenter(cbus) := _ }
+    
+    bus_blocker.node
+  }
+}


### PR DESCRIPTION
The QSPI case is a bit awkward because we need one blocker for each node type; for now I just make their addresses contiguous.