### PR TITLE
Set PeripheryKey defaults to Nil

### DIFF
--- a/src/main/scala/devices/gpio/GPIOPeriphery.scala
+++ b/src/main/scala/devices/gpio/GPIOPeriphery.scala
@@ -5,7 +5,7 @@ import freechips.rocketchip.config.Field
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.BaseSubsystem
 
-case object PeripheryGPIOKey extends Field[Seq[GPIOParams]]
+case object PeripheryGPIOKey extends Field[Seq[GPIOParams]](Nil)
 
 trait HasPeripheryGPIO { this: BaseSubsystem =>
   val gpioNodes = p(PeripheryGPIOKey).map { ps => GPIO.attach(GPIOAttachParams(ps, pbus, ibus.fromAsync)).ioNode.makeSink }

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -6,7 +6,7 @@ import freechips.rocketchip.config.Field
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.{BaseSubsystem}
 
-case object PeripheryI2CKey extends Field[Seq[I2CParams]]
+case object PeripheryI2CKey extends Field[Seq[I2CParams]](Nil)
 
 trait HasPeripheryI2C { this: BaseSubsystem =>
   val i2cNodes =  p(PeripheryI2CKey).map { ps =>

--- a/src/main/scala/devices/pwm/PWMPeriphery.scala
+++ b/src/main/scala/devices/pwm/PWMPeriphery.scala
@@ -6,7 +6,7 @@ import freechips.rocketchip.config.Field
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.BaseSubsystem
 
-case object PeripheryPWMKey extends Field[Seq[PWMParams]]
+case object PeripheryPWMKey extends Field[Seq[PWMParams]](Nil)
 
 trait HasPeripheryPWM { this: BaseSubsystem =>
   val pwmNodes = p(PeripheryPWMKey).map { ps => PWM.attach(PWMAttachParams(ps, pbus, ibus.fromAsync)).ioNode.makeSink }

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -6,7 +6,7 @@ import freechips.rocketchip.config.Field
 import freechips.rocketchip.subsystem.{BaseSubsystem}
 import freechips.rocketchip.diplomacy._
 
-case object PeripherySPIKey extends Field[Seq[SPIParams]]
+case object PeripherySPIKey extends Field[Seq[SPIParams]](Nil)
 
 trait HasPeripherySPI { this: BaseSubsystem =>
   val spiNodes = p(PeripherySPIKey).map { ps => SPI.attach(SPIAttachParams(ps, pbus, ibus.fromAsync)).ioNode.makeSink() }
@@ -21,7 +21,7 @@ trait HasPeripherySPIModuleImp extends LazyModuleImp with HasPeripherySPIBundle 
   val spi  = outer.spiNodes.zipWithIndex.map  { case(n,i) => n.makeIO()(ValName(s"spi_$i")) }
 }
 
-case object PeripherySPIFlashKey extends Field[Seq[SPIFlashParams]]
+case object PeripherySPIFlashKey extends Field[Seq[SPIFlashParams]](Nil)
 
 trait HasPeripherySPIFlash { this: BaseSubsystem =>
   val qspiNodes = p(PeripherySPIFlashKey).map { ps =>

--- a/src/main/scala/devices/uart/UARTPeriphery.scala
+++ b/src/main/scala/devices/uart/UARTPeriphery.scala
@@ -5,7 +5,7 @@ import freechips.rocketchip.config.Field
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.{BaseSubsystem, PeripheryBusKey}
 
-case object PeripheryUARTKey extends Field[Seq[UARTParams]]
+case object PeripheryUARTKey extends Field[Seq[UARTParams]](Nil)
 
 trait HasPeripheryUART { this: BaseSubsystem =>
   val uartNodes = p(PeripheryUARTKey).map { ps =>


### PR DESCRIPTION
We would like to use the `HasPeripheryX` traits more like `CanHavePeripheryX`. Setting the `PeripheryXKey` defaults to `Nil` lets us do this without adding a `WithNoX` mixin to all our configurations.