### PR TITLE
SynchronizerShiftReg no longer allows sync=0

### DIFF
--- a/src/main/scala/devices/i2c/I2CPins.scala
+++ b/src/main/scala/devices/i2c/I2CPins.scala
@@ -19,13 +19,13 @@ object I2CPinsFromPort {
     withClockAndReset(clock, reset) {
       pins.scl.outputPin(i2c.scl.out, pue=true.B, ie = true.B)
       pins.scl.o.oe := i2c.scl.oe
-      i2c.scl.in := SyncResetSynchronizerShiftReg(pins.scl.i.ival, syncStages, init = Bool(true),
-        name = Some("i2c_scl_sync"))
+      i2c.scl.in := (if (syncStages == 0) pins.scl.i.ival else SyncResetSynchronizerShiftReg(pins.scl.i.ival, syncStages, init = Bool(true),
+        name = Some("i2c_scl_sync")))
 
       pins.sda.outputPin(i2c.sda.out, pue=true.B, ie = true.B)
       pins.sda.o.oe := i2c.sda.oe
-      i2c.sda.in := SyncResetSynchronizerShiftReg(pins.sda.i.ival, syncStages, init = Bool(true),
-        name = Some("i2c_sda_sync"))
+      i2c.sda.in := (if (syncStages == 0) pins.sda.i.ival else SyncResetSynchronizerShiftReg(pins.sda.i.ival, syncStages, init = Bool(true),
+        name = Some("i2c_sda_sync")))
     }
   }
 }

--- a/src/main/scala/devices/spi/SPIPins.scala
+++ b/src/main/scala/devices/spi/SPIPins.scala
@@ -27,7 +27,7 @@ object SPIPinsFromPort {
         p.outputPin(s.o, pue = Bool(true), ds = driveStrength)
         p.o.oe := s.oe
         p.o.ie := ~s.oe
-        s.i := SynchronizerShiftReg(p.i.ival, syncStages, name = Some(s"spi_dq_${i}_sync"))
+        s.i := (if (syncStages == 0) p.i.ival else SynchronizerShiftReg(p.i.ival, syncStages, name = Some(s"spi_dq_${i}_sync")))
       }
 
       (pins.cs zip spi.cs) foreach { case (c, s) =>

--- a/src/main/scala/devices/uart/UARTPins.scala
+++ b/src/main/scala/devices/uart/UARTPins.scala
@@ -18,7 +18,7 @@ object UARTPinsFromPort {
     withClockAndReset(clock, reset) {
       pins.txd.outputPin(uart.txd)
       val rxd_t = pins.rxd.inputPin()
-      uart.rxd := SyncResetSynchronizerShiftReg(rxd_t, syncStages, init = Bool(true), name = Some("uart_rxd_sync"))
+      uart.rxd := (if (syncStages == 0) rxd_t else SyncResetSynchronizerShiftReg(rxd_t, syncStages, init = Bool(true), name = Some("uart_rxd_sync")))
     }
   }
 }


### PR DESCRIPTION
With pending changes to the synchronizer primitives in https://github.com/chipsalliance/rocket-chip/pull/2212, sync=0 is no longer allowed as a shortcut to bypass the synchronizer altogether.  This PR adds scala code to explicitly bypass the synchronizer in this case.
