### PR TITLE
Chisel compile warning: TileLink Parameters v1

### DIFF
--- a/src/main/scala/devices/msi/MSIMaster.scala
+++ b/src/main/scala/devices/msi/MSIMaster.scala
@@ -17,7 +17,7 @@ case class MSITarget(address: BigInt, spacing: Int, number: Int)
 
 class MSIMaster(targets: Seq[MSITarget])(implicit p: Parameters) extends LazyModule
 {
-  val masterNode = TLClientNode(Seq(TLClientPortParameters(Seq(TLClientParameters("MSI Master", sourceId = IdRange(0,2))))))
+  val masterNode = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLMasterParameters.v1("MSI Master", sourceId = IdRange(0,2))))))
 
   // A terminal interrupt node of flexible number
   val intNode = IntNexusNode(

--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -116,8 +116,8 @@ class SPIFlashTopModule(c: SPIFlashParamsBase, outer: TLSPIFlashBase)
 
 abstract class TLSPIFlashBase(w: Int, c: SPIFlashParamsBase)(implicit p: Parameters) extends TLSPIBase(w,c)(p) {
   require(isPow2(c.fSize))
-  val fnode = TLManagerNode(Seq(TLManagerPortParameters(
-    managers = Seq(TLManagerParameters(
+  val fnode = TLManagerNode(Seq(TLSlavePortParameters.v1(
+    managers = Seq(TLSlaveParameters.v1(
       address     = Seq(AddressSet(c.fAddress, c.fSize-1)),
       resources   = device.reg("mem"),
       regionType  = RegionType.UNCACHED,


### PR DESCRIPTION
### Why is this change being made?
fix these Chisel compile warnings:
```
method apply in object TLClientParameters is deprecated: Use TLMasterParameters.v1 instead of TLClientParameters
method apply in object TLClientPortParameters is deprecated: Use TLMasterPortParameters.v1 instead of TLClientPortParameters
method apply in object TLManagerParameters is deprecated: Use TLSlaveParameters.v1 instead of TLManagerParameters
method apply in object TLManagerPortParameters is deprecated: Use TLSlavePortParameters.v1 instead of TLManagerPortParameters
```

### Type of change
- Paying Off Technical Debt
