### PR TITLE
Chisel compile warning: deprecated IntSyncCrossingSink

### DIFF
--- a/src/main/scala/devices/mockaon/MockAONPeriphery.scala
+++ b/src/main/scala/devices/mockaon/MockAONPeriphery.scala
@@ -19,7 +19,7 @@ trait HasPeripheryMockAON extends CanHavePeripheryCLINT with HasPeripheryDebug {
   val mockAONParams= p(PeripheryMockAONKey)
   val aon = LazyModule(new MockAONWrapper(cbus.beatBytes, mockAONParams))
   aon.node := cbus.coupleTo("aon") { TLAsyncCrossingSource() := TLFragmenter(cbus) := _ }
-  ibus.fromSync := IntSyncCrossingSink() := aon.intnode
+  ibus.fromSync := IntSyncAsyncCrossingSink() := aon.intnode
 }
 
 trait HasPeripheryMockAONBundle {


### PR DESCRIPTION
### Why is this change being made?

fix this Chisel compile warning:
```
[warn] /federation/sifive-blocks/src/main/scala/devices/mockaon/MockAONPeriphery.scala:22:20: method apply in object IntSyncCrossingSink is deprecated (since rocket-chip 1.2): IntSyncCrossingSink which used the `sync` parameter to determine crossing type is deprecated. Use IntSyncAsyncCrossingSink, IntSyncRationalCrossingSink, or IntSyncSyncCrossingSink instead for > 1, 1, and 0 sync values respectively
[warn]   ibus.fromSync := IntSyncCrossingSink() := aon.intnode
[warn]                    ^
```

### Type of change
- Paying Off Technical Debt
