### PR TITLE
Timer: revert maxcmp change from 8 back to 4

### DIFF
--- a/src/main/scala/util/Timer.scala
+++ b/src/main/scala/util/Timer.scala
@@ -180,7 +180,7 @@ trait GenericTimer {
   protected def gang: Vec[Bool] = Vec.fill(ncmp){Bool(false)}
   protected val scaleWidth = 4
   protected val regWidth = 32
-  val maxcmp = 8
+  val maxcmp = 4
   require(ncmp <= maxcmp)
   require(ncmp > 0)
 


### PR DESCRIPTION
This broke tests in a larger repository.
This changed came in PR #141, but do not seem necessary.