### PR TITLE
Support for configurable hierarchies

### DIFF
--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -3,12 +3,12 @@ package sifive.blocks.devices.gpio
 
 import Chisel._
 
-import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.prci._
 import freechips.rocketchip.regmapper._
-import freechips.rocketchip.subsystem.{Attachable, TLBusWrapperLocation, PBUS}
+import freechips.rocketchip.subsystem._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.util.{AsyncResetRegVec, SynchronizerShiftReg}
@@ -235,6 +235,8 @@ abstract class GPIO(busWidthBytes: Int, c: GPIOParams)(implicit p: Parameters)
 
 class TLGPIO(busWidthBytes: Int, params: GPIOParams)(implicit p: Parameters)
   extends GPIO(busWidthBytes, params) with HasTLControlRegMap
+
+case class GPIOLocated(loc: HierarchicalLocation) extends Field[Seq[GPIOAttachParams]](Nil)
 
 case class GPIOAttachParams(
   device: GPIOParams,

--- a/src/main/scala/devices/i2c/I2C.scala
+++ b/src/main/scala/devices/i2c/I2C.scala
@@ -42,12 +42,12 @@
 package sifive.blocks.devices.i2c
 
 import Chisel._
-import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.prci._
 import freechips.rocketchip.regmapper._
-import freechips.rocketchip.subsystem.{Attachable, TLBusWrapperLocation, PBUS}
+import freechips.rocketchip.subsystem._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.util.{AsyncResetRegVec, Majority}
@@ -579,6 +579,8 @@ abstract class I2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters
 
 class TLI2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters)
   extends I2C(busWidthBytes, params) with HasTLControlRegMap
+
+case class I2CLocated(loc: HierarchicalLocation) extends Field[Seq[I2CAttachParams]](Nil)
 
 case class I2CAttachParams(
   device: I2CParams,

--- a/src/main/scala/devices/pwm/PWM.scala
+++ b/src/main/scala/devices/pwm/PWM.scala
@@ -5,12 +5,12 @@ import Chisel._
 import Chisel.ImplicitConversions._
 import chisel3.MultiIOModule
 
-import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.prci._
 import freechips.rocketchip.regmapper._
-import freechips.rocketchip.subsystem.{Attachable, TLBusWrapperLocation, PBUS}
+import freechips.rocketchip.subsystem._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.util._
@@ -117,6 +117,8 @@ abstract class PWM(busWidthBytes: Int, val params: PWMParams)(implicit p: Parame
 
 class TLPWM(busWidthBytes: Int, params: PWMParams)(implicit p: Parameters)
   extends PWM(busWidthBytes, params) with HasTLControlRegMap
+
+case class PWMLocated(loc: HierarchicalLocation) extends Field[Seq[PWMAttachParams]](Nil)
 
 case class PWMAttachParams(
   device: PWMParams,

--- a/src/main/scala/devices/spi/SPI.scala
+++ b/src/main/scala/devices/spi/SPI.scala
@@ -3,14 +3,14 @@ package sifive.blocks.devices.spi
 
 import Chisel._
 
-import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.util._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.prci._
 import freechips.rocketchip.regmapper._
-import freechips.rocketchip.subsystem.{Attachable, TLBusWrapperLocation, PBUS}
+import freechips.rocketchip.subsystem._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
@@ -18,6 +18,8 @@ import freechips.rocketchip.diplomaticobjectmodel.model.{OMComponent, OMRegister
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{LogicalModuleTree, LogicalTreeNode}
 
 import sifive.blocks.util._
+
+case class SPILocated(loc: HierarchicalLocation) extends Field[Seq[SPIAttachParams]](Nil)
 
 case class SPIAttachParams(
   device: SPIParams,
@@ -69,6 +71,8 @@ case class SPIAttachParams(
     spi
   }
 }
+
+case class SPIFlashLocated(loc: HierarchicalLocation) extends Field[Seq[SPIFlashAttachParams]](Nil)
 
 case class SPIFlashAttachParams(
   device: SPIFlashParams,

--- a/src/main/scala/devices/stream/PseudoStream.scala
+++ b/src/main/scala/devices/stream/PseudoStream.scala
@@ -3,11 +3,11 @@ package sifive.blocks.devices.stream
 
 import Chisel._
 
-import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.prci._
 import freechips.rocketchip.regmapper._
-import freechips.rocketchip.subsystem.{Attachable, TLBusWrapperLocation, SBUS}
+import freechips.rocketchip.subsystem._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.devices.tilelink._
 
@@ -91,6 +91,8 @@ abstract class PseudoStream(busWidthBytes: Int, val params: PseudoStreamParams)(
 
 class TLPseudoStream(busWidthBytes: Int, params: PseudoStreamParams)(implicit p: Parameters)
   extends PseudoStream(busWidthBytes, params) with HasTLControlRegMap
+
+case class PseudoStreamLocated(loc: HierarchicalLocation) extends Field[Seq[PseudoStreamAttachParams]](Nil)
 
 case class PseudoStreamAttachParams(
   device: PseudoStreamParams,

--- a/src/main/scala/devices/timer/Timer.scala
+++ b/src/main/scala/devices/timer/Timer.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.prci._
 import freechips.rocketchip.regmapper.{RegisterRouter, RegisterRouterParams}
-import freechips.rocketchip.subsystem.{Attachable, TLBusWrapperLocation, PBUS}
+import freechips.rocketchip.subsystem._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
@@ -75,6 +75,8 @@ trait HasPeripheryTimer { this: BaseSubsystem =>
     timer
   }
 }
+
+case class TimerLocated(loc: HierarchicalLocation) extends Field[Seq[TimerAttachParams]](Nil)
 
 case class TimerAttachParams(
   device: TimerParams,

--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -3,12 +3,12 @@ package sifive.blocks.devices.uart
 
 import Chisel._
 
-import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.prci._
 import freechips.rocketchip.regmapper._
-import freechips.rocketchip.subsystem.{Attachable, TLBusWrapperLocation, PBUS}
+import freechips.rocketchip.subsystem._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.util._
@@ -222,6 +222,8 @@ class UART(busWidthBytes: Int, val c: UARTParams, divisorInit: Int = 0)
 }
 class TLUART(busWidthBytes: Int, params: UARTParams, divinit: Int)(implicit p: Parameters)
   extends UART(busWidthBytes, params, divinit) with HasTLControlRegMap
+
+case class UARTLocated(loc: HierarchicalLocation) extends Field[Seq[UARTAttachParams]](Nil)
 
 case class UARTAttachParams(
   device: UARTParams,

--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -238,6 +238,8 @@ case class UARTAttachParams(
     val uart = uartClockDomainWrapper { LazyModule(new TLUART(tlbus.beatBytes, device, divinit)) }
     uart.suggestName(name)
 
+    println(s"${where.ibus}")
+
     tlbus.coupleTo(s"device_named_$name") { bus =>
 
       val blockerOpt = blockerAddr.map { a =>

--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -238,8 +238,6 @@ case class UARTAttachParams(
     val uart = uartClockDomainWrapper { LazyModule(new TLUART(tlbus.beatBytes, device, divinit)) }
     uart.suggestName(name)
 
-    println(s"${where.ibus}")
-
     tlbus.coupleTo(s"device_named_$name") { bus =>
 
       val blockerOpt = blockerAddr.map { a =>

--- a/src/main/scala/devices/wdt/TLWDT.scala
+++ b/src/main/scala/devices/wdt/TLWDT.scala
@@ -5,13 +5,13 @@ import Chisel._
 import Chisel.ImplicitConversions._
 import chisel3.MultiIOModule
 
-import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.prci._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.subsystem.{Attachable, TLBusWrapperLocation, PBUS}
+import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.util._
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
@@ -70,6 +70,8 @@ abstract class WDT(busWidthBytes: Int, val params: WDTParams)(implicit p: Parame
 
 class TLWDT(busWidthBytes: Int, params: WDTParams)(implicit p: Parameters)
   extends WDT(busWidthBytes, params) with HasTLControlRegMap
+
+case class WDTLocated(loc: HierarchicalLocation) extends Field[Seq[WDTAttachParams]](Nil)
 
 case class WDTAttachParams(
   device: WDTParams,

--- a/src/main/scala/util/Devices.scala
+++ b/src/main/scala/util/Devices.scala
@@ -16,10 +16,10 @@ trait CanHaveDevices { this: Attachable =>
   def devicesSubhierarchies: Option[Seq[CanHaveDevices]]
 
   val devicesConfigs: Seq[DeviceAttachParams] = p(DevicesLocated(location)) ++
-    devicesSubhierarchies.map(_.filter(_.location != location).map(_.devicesConfigs)).getOrElse(Nil).flatten
+    devicesSubhierarchies.map(_.map(_.devicesConfigs)).getOrElse(Nil).flatten
 
   val devices: Seq[LazyModule] = p(DevicesLocated(location)).map(_.attachTo(this)) ++
-    devicesSubhierarchies.map(_.filter(_.location != location).map(_.devices)).getOrElse(Nil).flatten
+    devicesSubhierarchies.map(_.map(_.devices)).getOrElse(Nil).flatten
 }
 
 trait DeviceParams

--- a/src/main/scala/util/Devices.scala
+++ b/src/main/scala/util/Devices.scala
@@ -4,8 +4,10 @@ package sifive.blocks.util
 import Chisel._
 
 import freechips.rocketchip.config.{Field, Parameters}
+import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalTreeNode
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.prci._
 import freechips.rocketchip.regmapper.RegisterRouter
 import freechips.rocketchip.subsystem._
 
@@ -31,4 +33,24 @@ trait DeviceAttachParams {
   val controlXType: ClockCrossingType
 
   def attachTo(where: Attachable)(implicit p: Parameters): LazyModule
+}
+
+case class DevicesSubsystemParams(
+  name: String,
+  logicalTreeNode: LogicalTreeNode,
+  asyncClockGroupsNode: ClockGroupEphemeralNode)
+
+class DevicesSubsystem(val location: HierarchicalLocation, val ibus: InterruptBusWrapper, params: DevicesSubsystemParams)(implicit p: Parameters)
+  extends LazyModule
+    with Attachable
+    with HasConfigurableTLNetworkTopology
+    with CanHaveDevices {
+
+  def devicesSubhierarchies = None
+  def logicalTreeNode = params.logicalTreeNode
+  implicit val asyncClockGroupsNode = params.asyncClockGroupsNode
+
+  lazy val module = new LazyModuleImp(this) {
+    override def desiredName: String = params.name
+  }
 }

--- a/src/main/scala/util/Devices.scala
+++ b/src/main/scala/util/Devices.scala
@@ -13,10 +13,13 @@ case class DevicesLocated(loc: HierarchicalLocation) extends Field[Seq[DeviceAtt
 
 trait CanHaveDevices { this: Attachable =>
   def location: HierarchicalLocation
-  val ibus: InterruptBusWrapper
-  //val subHierarchies: Option[Seq[CanHaveDevices]]
-  val devicesConfigs: Seq[DeviceAttachParams] = p(DevicesLocated(location))// ++ subHierarchies.foreach(_.foreach(_.devicesConfigs))
-  val devices: Seq[LazyModule] = devicesConfigs.map(_.attachTo(this))// ++ subHierarchies.foreach(_.foreach(_.devices))
+  def devicesSubhierarchies: Option[Seq[CanHaveDevices]]
+
+  val devicesConfigs: Seq[DeviceAttachParams] = p(DevicesLocated(location)) ++
+    devicesSubhierarchies.map(_.filter(_.location != location).map(_.devicesConfigs)).getOrElse(Nil).flatten
+
+  val devices: Seq[LazyModule] = p(DevicesLocated(location)).map(_.attachTo(this)) ++
+    devicesSubhierarchies.map(_.filter(_.location != location).map(_.devices)).getOrElse(Nil).flatten
 }
 
 trait DeviceParams

--- a/src/main/scala/util/Devices.scala
+++ b/src/main/scala/util/Devices.scala
@@ -7,14 +7,16 @@ import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper.RegisterRouter
-import freechips.rocketchip.subsystem.{Attachable, TLBusWrapperLocation, HierarchicalLocation}
+import freechips.rocketchip.subsystem._
 
 case class DevicesLocated(loc: HierarchicalLocation) extends Field[Seq[DeviceAttachParams]](Nil)
 
 trait CanHaveDevices { this: Attachable =>
   def location: HierarchicalLocation
-  val devicesConfigs: Seq[DeviceAttachParams] = p(DevicesLocated(location))
-  val devices: Seq[LazyModule] = devicesConfigs.map(_.attachTo(this))
+  val ibus: InterruptBusWrapper
+  //val subHierarchies: Option[Seq[CanHaveDevices]]
+  val devicesConfigs: Seq[DeviceAttachParams] = p(DevicesLocated(location))// ++ subHierarchies.foreach(_.foreach(_.devicesConfigs))
+  val devices: Seq[LazyModule] = devicesConfigs.map(_.attachTo(this))// ++ subHierarchies.foreach(_.foreach(_.devices))
 }
 
 trait DeviceParams

--- a/src/main/scala/util/Hierarchy.scala
+++ b/src/main/scala/util/Hierarchy.scala
@@ -17,8 +17,8 @@ import firrtl.graph._
 
 case object HierarchyKey extends Field[Option[DiGraph[HierarchicalLocation]]](None)
 
-case object DSS00 extends HierarchicalLocation("DSS00")
-case object DSS01 extends HierarchicalLocation("DSS01")
+case object DSS0 extends HierarchicalLocation("DSS0")
+case object DSS1 extends HierarchicalLocation("DSS1")
 
 case class DevicesSubsystemParams(
   name: String,
@@ -58,8 +58,8 @@ trait HasConfigurableHierarchy { this: Attachable =>
         name = edge.name,
         logicalTreeNode = this.logicalTreeNode,
         asyncClockGroupsNode = this.asyncClockGroupsNode)
-      val dss = context { LazyModule(new DevicesSubsystem(edge, ibus, essParams)) }
-      createHierarchyMap(edge, graph, ess)
+      val dss = context { LazyModule(new DevicesSubsystem(edge, ibus, dssParams)) }
+      createHierarchyMap(edge, graph, dss)
     }
   }
 
@@ -81,7 +81,7 @@ class Hierarchy(val root: HierarchicalLocation) {
   }
 
   def addSubhierarchies(parent: HierarchicalLocation, children: Seq[HierarchicalLocation]): Unit = {
-    children.foreach(addSubhierarchy(_))
+    children.foreach(addSubhierarchy(parent,_))
   }
 
   def closeHierarchy(): DiGraph[HierarchicalLocation] = {

--- a/src/main/scala/util/Hierarchy.scala
+++ b/src/main/scala/util/Hierarchy.scala
@@ -34,10 +34,8 @@ class EmptySubsystem(val location: HierarchicalLocation = ESS0, val ibus: Interr
     with HasConfigurableTLNetworkTopology 
     with CanHaveDevices {
 
-  println(s"\n\n\nCreating EmptySubsystem with location = ${location.name}\n\n\n")
+  def devicesSubhierarchies = None
 
-  //val ibus = params.ibus
-  println(s"Printing ibus from ESS: ${ibus}")
   def logicalTreeNode = params.logicalTreeNode
   implicit val asyncClockGroupsNode = params.asyncClockGroupsNode
 
@@ -49,24 +47,17 @@ class EmptySubsystem(val location: HierarchicalLocation = ESS0, val ibus: Interr
 trait HasConfigurableHierarchy { this: Attachable =>
   def location: HierarchicalLocation
 
-  println(s"Printing ibus from trait HasConfigurableHierarchy: ${ibus}")
   def createHierarchyMap(
     root: HierarchicalLocation,
     graph: DiGraph[HierarchicalLocation],
     context: Attachable): Unit = {
 
-    println(s"Printing ibus from createHierarcyMap: ${ibus}")
-
-    // Add the current hierarchy's bus map to the bus map map
-    println(s"\n\n\nAdding ESS ${root.name} to busLocationFunctions\n\n\n")
     busLocationFunctions += (root -> context.tlBusWrapperLocationMap)
-
-    println(s"\n\n\nbusLocationFunctions = ${busLocationFunctions}\n")
+    hierarchyMap += (root -> context)
 
     // Create and recurse on child hierarchies
     val edges = graph.getEdges(root)
     edges.foreach { edge =>
-      println(s"\n\nCreating hierarchy ${edge.name}\n\n")
       val essParams = EmptySubsystemParams(
         name = edge.name,
         ibus = this.ibus,
@@ -81,11 +72,8 @@ trait HasConfigurableHierarchy { this: Attachable =>
 
 
   val busLocationFunctions = LocationMap.empty[LocationMap[TLBusWrapper]]
+  val hierarchyMap = LocationMap.empty[Attachable]
   p(HierarchyKey).foreach(createHierarchyMap(location, _, this))
-  println("\n\n\nPrinting p(HierarchyKey):")
-  println(p(HierarchyKey))
-  println("\n\n\nPrinting generated busLocationFunctions:")
-  println(busLocationFunctions)
 
 }
 

--- a/src/main/scala/util/Hierarchy.scala
+++ b/src/main/scala/util/Hierarchy.scala
@@ -17,9 +17,6 @@ import firrtl.graph._
 
 case object HierarchyKey extends Field[Option[DiGraph[HierarchicalLocation]]](None)
 
-case object DSS0 extends HierarchicalLocation("DSS0")
-case object DSS1 extends HierarchicalLocation("DSS1")
-
 case class DevicesSubsystemParams(
   name: String,
   logicalTreeNode: LogicalTreeNode,

--- a/src/main/scala/util/Hierarchy.scala
+++ b/src/main/scala/util/Hierarchy.scala
@@ -1,0 +1,110 @@
+// See LICENSE for license details.
+
+package sifive.blocks.util
+
+import chisel3._
+import chisel3.util._
+
+import freechips.rocketchip.config._
+import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalTreeNode
+import freechips.rocketchip.tilelink._
+import freechips.rocketchip.subsystem._
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.prci._
+import freechips.rocketchip.util.LocationMap
+
+import firrtl.graph._
+
+case object HierarchyKey extends Field[DiGraph[HierarchicalLocation]]
+
+case object ESS0 extends HierarchicalLocation("ESS0")
+case object ESS1 extends HierarchicalLocation("ESS1")
+
+case class EmptySubsystemParams(
+  name: String,
+  location: HierarchicalLocation,
+  ibus: InterruptBusWrapper,
+  logicalTreeNode: LogicalTreeNode,
+  asyncClockGroupsNode: ClockGroupEphemeralNode)
+
+class EmptySubsystem(params: EmptySubsystemParams)(implicit p: Parameters) extends LazyModule 
+  with Attachable
+  with HasConfigurableTLNetworkTopology
+  with CanHaveDevices {
+
+  val location = params.location
+
+  val ibus = params.ibus
+  def logicalTreeNode = params.logicalTreeNode
+  implicit val asyncClockGroupsNode = params.asyncClockGroupsNode
+
+  lazy val module = new LazyModuleImp(this) {
+    //override def desiredName: String = name
+  }
+}
+
+trait HasConfigurableHierarchy { this: Attachable =>
+  def location: HierarchicalLocation
+
+  def createHierarchyMap(
+    root: HierarchicalLocation,
+    graph: DiGraph[HierarchicalLocation],
+    context: Attachable): Unit = {
+
+    // TODO: Need to aggregate locateTLBusWrapper functions for each location
+    // Add the current hiearchy to the map
+    // hierarchyMap += (root -> context)
+
+    // Create and recurse on child hierarchies
+    val edges = graph.getEdges(root)
+    edges.foreach { edge =>
+      val essParams = EmptySubsystemParams(
+        name = edge.name,
+        ibus = this.ibus,
+        location = edge,
+        logicalTreeNode = this.logicalTreeNode,
+        asyncClockGroupsNode = this.asyncClockGroupsNode)
+      val ess = context { LazyModule(new EmptySubsystem(essParams)) }
+      createHierarchyMap(edge, graph, ess)
+    }
+  }
+
+
+  val hierarchyMap = LocationMap.empty[Attachable]
+  createHierarchyMap(location, p(HierarchyKey), this)
+  println("\n\n\nPrinting p(HierarchyKey):")
+  println(p(HierarchyKey))
+  println("\n\n\nPrinting generated hierarchyMap:")
+  println(hierarchyMap)
+
+}
+
+class Hierarchy(val root: HierarchicalLocation) {
+  require(root == InSystem || root == InSubsystem, "Invalid root hierarchy")
+
+  val graph = new MutableDiGraph[HierarchicalLocation]
+  graph.addVertex(root)
+
+  def addSubhierarchy(parent: HierarchicalLocation, child: HierarchicalLocation): Unit = {
+    graph.addVertex(child)
+    graph.addEdge(parent,child) 
+  }
+
+  def closeHierarchy(): DiGraph[HierarchicalLocation] = {
+    DiGraph(graph)
+  }
+
+}
+
+object Hierarchy {
+  def init(root: HierarchicalLocation): Hierarchy = {
+    val hierarchy = new Hierarchy(root)
+    hierarchy
+  }
+
+  def default(root: HierarchicalLocation): DiGraph[HierarchicalLocation] = {
+    val h = init(root)
+    h.closeHierarchy()
+  }
+
+}

--- a/src/main/scala/util/Hierarchy.scala
+++ b/src/main/scala/util/Hierarchy.scala
@@ -46,7 +46,6 @@ trait HasConfigurableHierarchy { this: Attachable =>
   }
 
   val hierarchyMap = LocationMap.empty[Attachable]
-
   p(HierarchyKey).foreach(createHierarchyMap(location, _, this))
 
   hierarchyMap.foreach { case(label, context) =>

--- a/src/main/scala/util/Hierarchy.scala
+++ b/src/main/scala/util/Hierarchy.scala
@@ -15,7 +15,7 @@ import freechips.rocketchip.util.LocationMap
 
 import firrtl.graph._
 
-case object HierarchyKey extends Field[DiGraph[HierarchicalLocation]]
+case object HierarchyKey extends Field[Option[DiGraph[HierarchicalLocation]]](None)
 
 case object ESS0 extends HierarchicalLocation("ESS0")
 case object ESS1 extends HierarchicalLocation("ESS1")
@@ -71,7 +71,7 @@ trait HasConfigurableHierarchy { this: Attachable =>
 
 
   val hierarchyMap = LocationMap.empty[Attachable]
-  createHierarchyMap(location, p(HierarchyKey), this)
+  p(HierarchyKey).foreach(createHierarchyMap(location, _, this))
   println("\n\n\nPrinting p(HierarchyKey):")
   println(p(HierarchyKey))
   println("\n\n\nPrinting generated hierarchyMap:")

--- a/src/main/scala/util/Hierarchy.scala
+++ b/src/main/scala/util/Hierarchy.scala
@@ -23,8 +23,6 @@ case object ESS1 extends HierarchicalLocation("ESS1")
 
 case class EmptySubsystemParams(
   name: String,
-  location: HierarchicalLocation,
-  ibus: InterruptBusWrapper,
   logicalTreeNode: LogicalTreeNode,
   asyncClockGroupsNode: ClockGroupEphemeralNode)
 
@@ -40,7 +38,7 @@ class EmptySubsystem(val location: HierarchicalLocation = ESS0, val ibus: Interr
   implicit val asyncClockGroupsNode = params.asyncClockGroupsNode
 
   lazy val module = new LazyModuleImp(this) {
-    //override def desiredName: String = name
+    override def desiredName: String = params.name
   }
 }
 
@@ -60,8 +58,6 @@ trait HasConfigurableHierarchy { this: Attachable =>
     edges.foreach { edge =>
       val essParams = EmptySubsystemParams(
         name = edge.name,
-        ibus = this.ibus,
-        location = edge,
         logicalTreeNode = this.logicalTreeNode,
         asyncClockGroupsNode = this.asyncClockGroupsNode)
       val ess = context { LazyModule(new EmptySubsystem(edge, ibus, essParams)) }

--- a/src/main/scala/util/Hierarchy.scala
+++ b/src/main/scala/util/Hierarchy.scala
@@ -62,6 +62,14 @@ trait HasConfigurableHierarchy { this: Attachable =>
     }
   }
 
+  def getDevicesSubhierarchies: Seq[CanHaveDevices] = {
+    hierarchyMap
+      .values
+      .toSeq
+      .asInstanceOf[Seq[CanHaveDevices]]
+      .filter(_.location != location)
+  }
+
   val busLocationFunctions = LocationMap.empty[LocationMap[TLBusWrapper]]
   val hierarchyMap = LocationMap.empty[Attachable]
 

--- a/src/main/scala/util/Hierarchy.scala
+++ b/src/main/scala/util/Hierarchy.scala
@@ -48,7 +48,6 @@ trait HasConfigurableHierarchy { this: Attachable =>
     graph: DiGraph[HierarchicalLocation],
     context: Attachable): Unit = {
 
-    busLocationFunctions += (root -> context.tlBusWrapperLocationMap)
     hierarchyMap += (root -> context)
 
     // Create and recurse on child hierarchies
@@ -65,8 +64,12 @@ trait HasConfigurableHierarchy { this: Attachable =>
 
   val busLocationFunctions = LocationMap.empty[LocationMap[TLBusWrapper]]
   val hierarchyMap = LocationMap.empty[Attachable]
+
   p(HierarchyKey).foreach(createHierarchyMap(location, _, this))
-  busLocationFunctions.foreach { case(hier, func) => tlBusWrapperLocationMap ++= func }
+
+  hierarchyMap.foreach { case(label, context) =>
+    tlBusWrapperLocationMap ++= context.tlBusWrapperLocationMap
+  }
 }
 
 class Hierarchy(val root: HierarchicalLocation) {


### PR DESCRIPTION
Adds Hierarchy.scala, which introduces `CanHaveConfigurableHierarchy` and `DevicesSubsystem`, a system populated only by a `TLNetworkTopologyLocated` and whichever devices are specified in `DevicesLocated`