### PR TITLE
TileLink Diplomacy parameters supportsProbe -> supports.probe

### DIFF
--- a/src/main/scala/devices/chiplink/ChipLink.scala
+++ b/src/main/scala/devices/chiplink/ChipLink.scala
@@ -138,8 +138,8 @@ class ChipLink(val params: ChipLinkParams)(implicit p: Parameters) extends LazyM
       s"ChipLink requires ${errorDev.name} support ${params.acqXfer} AcquireT, not ${errorDev.supportsAcquireT}")
 
     // At most one cache can master ChipLink
-    require (edgeIn.client.clients.filter(_.supportsProbe).size <= 1,
-      s"ChipLink supports at most one caching master, ${edgeIn.client.clients.filter(_.supportsProbe).map(_.name)}")
+    require (edgeIn.client.clients.filter(_.supports.probe).size <= 1,
+      s"ChipLink supports at most one caching master, ${edgeIn.client.clients.filter(_.supports.probe).map(_.name)}")
 
     // Construct the info needed by all submodules
     val info = ChipLinkInfo(params, edgeIn, edgeOut, errorDev.address.head)

--- a/src/main/scala/devices/chiplink/SourceB.scala
+++ b/src/main/scala/devices/chiplink/SourceB.scala
@@ -13,7 +13,7 @@ class SourceB(info: ChipLinkInfo) extends Module
   }
 
   // Find the optional cache (at most one)
-  val cache = info.edgeIn.client.clients.filter(_.supportsProbe).headOption
+  val cache = info.edgeIn.client.clients.filter(_.supports.probe).headOption
 
   // A simple FSM to generate the packet components
   val state = RegInit(UInt(0, width = 2))


### PR DESCRIPTION
### Why is this change being made?
fix these Chisel warnings:
```
[warn] /federation/sifive-blocks/src/main/scala/devices/chiplink/ChipLink.scala:141:45: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]     require (edgeIn.client.clients.filter(_.supportsProbe).size <= 1,
[warn]                                             ^
[warn] /federation/sifive-blocks/src/main/scala/devices/chiplink/ChipLink.scala:142:88: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]       s"ChipLink supports at most one caching master, ${edgeIn.client.clients.filter(_.supportsProbe).map(_.name)}")
[warn]                                                                                        ^
[warn] /federation/sifive-blocks/src/main/scala/devices/chiplink/SourceB.scala:16:51: method supportsProbe in class TLMasterParameters is deprecated: Use supports.probe instead of supportsProbe
[warn]   val cache = info.edgeIn.client.clients.filter(_.supportsProbe).headOption
[warn]                                                   ^
```

### Type of change
- Paying Off Technical Debt

### What was changed?
search-and-replace `supportsProbe` with `supports.probe` (and similar for other `supports.*`)