### PR TITLE
Enable AsyncReset in Chisel modules

### DIFF
--- a/src/main/scala/devices/chiplink/Bundles.scala
+++ b/src/main/scala/devices/chiplink/Bundles.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util.{rightOR,GenericParameterizedBundle}
 
 class WideDataLayerPortLane(params: ChipLinkParams) extends GenericParameterizedBundle(params) {

--- a/src/main/scala/devices/chiplink/ChipLink.scala
+++ b/src/main/scala/devices/chiplink/ChipLink.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/devices/chiplink/Parameters.scala
+++ b/src/main/scala/devices/chiplink/Parameters.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/devices/chiplink/Partial.scala
+++ b/src/main/scala/devices/chiplink/Partial.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/RX.scala
+++ b/src/main/scala/devices/chiplink/RX.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/SinkA.scala
+++ b/src/main/scala/devices/chiplink/SinkA.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkA(info: ChipLinkInfo) extends Module

--- a/src/main/scala/devices/chiplink/SinkB.scala
+++ b/src/main/scala/devices/chiplink/SinkB.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkB(info: ChipLinkInfo) extends Module

--- a/src/main/scala/devices/chiplink/SinkC.scala
+++ b/src/main/scala/devices/chiplink/SinkC.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkC(info: ChipLinkInfo) extends Module

--- a/src/main/scala/devices/chiplink/SinkD.scala
+++ b/src/main/scala/devices/chiplink/SinkD.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkD(info: ChipLinkInfo) extends Module

--- a/src/main/scala/devices/chiplink/SinkE.scala
+++ b/src/main/scala/devices/chiplink/SinkE.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 
 class SinkE(info: ChipLinkInfo) extends Module

--- a/src/main/scala/devices/chiplink/SourceA.scala
+++ b/src/main/scala/devices/chiplink/SourceA.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/SourceB.scala
+++ b/src/main/scala/devices/chiplink/SourceB.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/SourceC.scala
+++ b/src/main/scala/devices/chiplink/SourceC.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/SourceD.scala
+++ b/src/main/scala/devices/chiplink/SourceD.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/SourceE.scala
+++ b/src/main/scala/devices/chiplink/SourceE.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/chiplink/StuckSnooper.scala
+++ b/src/main/scala/devices/chiplink/StuckSnooper.scala
@@ -2,7 +2,8 @@
 
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/devices/chiplink/TX.scala
+++ b/src/main/scala/devices/chiplink/TX.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.chiplink
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.gpio
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/gpio/GPIOPins.scala
+++ b/src/main/scala/devices/gpio/GPIOPins.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.gpio
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import chisel3.{withClockAndReset}
 import sifive.blocks.devices.pinctrl.{Pin}
 

--- a/src/main/scala/devices/gpio/IOF.scala
+++ b/src/main/scala/devices/gpio/IOF.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.gpio
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import sifive.blocks.devices.pinctrl.{PinCtrl, Pin, BasePin, EnhancedPin, EnhancedPinCtrl}
 
 // This is the actual IOF interface.pa

--- a/src/main/scala/devices/i2c/I2C.scala
+++ b/src/main/scala/devices/i2c/I2C.scala
@@ -41,7 +41,8 @@
 
 package sifive.blocks.devices.i2c
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._

--- a/src/main/scala/devices/i2c/I2CPeriphery.scala
+++ b/src/main/scala/devices/i2c/I2CPeriphery.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.i2c
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Field
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.subsystem.{BaseSubsystem}

--- a/src/main/scala/devices/i2c/I2CPins.scala
+++ b/src/main/scala/devices/i2c/I2CPins.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.i2c
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import chisel3.{withClockAndReset}
 import freechips.rocketchip.util.SyncResetSynchronizerShiftReg
 import sifive.blocks.devices.pinctrl.{Pin, PinCtrl}

--- a/src/main/scala/devices/mockaon/MockAON.scala
+++ b/src/main/scala/devices/mockaon/MockAON.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.mockaon
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import chisel3.MultiIOModule
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.regmapper._

--- a/src/main/scala/devices/mockaon/MockAONPeriphery.scala
+++ b/src/main/scala/devices/mockaon/MockAONPeriphery.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.mockaon
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Field
 import freechips.rocketchip.devices.debug.HasPeripheryDebug
 import freechips.rocketchip.devices.tilelink.CanHavePeripheryCLINT

--- a/src/main/scala/devices/mockaon/MockAONWrapper.scala
+++ b/src/main/scala/devices/mockaon/MockAONWrapper.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.mockaon
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/devices/mockaon/PMU.scala
+++ b/src/main/scala/devices/mockaon/PMU.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.mockaon
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import Chisel.ImplicitConversions._
 import freechips.rocketchip.util._
 import sifive.blocks.util.SRLatch

--- a/src/main/scala/devices/mockaon/RTC.scala
+++ b/src/main/scala/devices/mockaon/RTC.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.mockaon
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import Chisel.ImplicitConversions._
 import chisel3.MultiIOModule
 import freechips.rocketchip.util.AsyncResetReg

--- a/src/main/scala/devices/mockaon/WatchdogTimer.scala
+++ b/src/main/scala/devices/mockaon/WatchdogTimer.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.mockaon
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import Chisel.ImplicitConversions._
 import chisel3.MultiIOModule
 import freechips.rocketchip.util.AsyncResetReg

--- a/src/main/scala/devices/msi/MSIMaster.scala
+++ b/src/main/scala/devices/msi/MSIMaster.scala
@@ -2,7 +2,8 @@
 
 package sifive.blocks.devices.msi
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._

--- a/src/main/scala/devices/pinctrl/PinCtrl.scala
+++ b/src/main/scala/devices/pinctrl/PinCtrl.scala
@@ -2,7 +2,8 @@
 
 package sifive.blocks.devices.pinctrl
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 // This is the base class of things you "always"
 // want to control from a HW block.

--- a/src/main/scala/devices/pwm/PWM.scala
+++ b/src/main/scala/devices/pwm/PWM.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.pwm
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import Chisel.ImplicitConversions._
 import chisel3.MultiIOModule
 

--- a/src/main/scala/devices/spi/SPI.scala
+++ b/src/main/scala/devices/spi/SPI.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.spi
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.util._

--- a/src/main/scala/devices/spi/SPIArbiter.scala
+++ b/src/main/scala/devices/spi/SPIArbiter.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.spi
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 class SPIInnerIO(c: SPIParamsBase) extends SPILinkIO(c) {
   val lock = Bool(OUTPUT)

--- a/src/main/scala/devices/spi/SPIBundle.scala
+++ b/src/main/scala/devices/spi/SPIBundle.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.spi
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 abstract class SPIBundle(val c: SPIParamsBase) extends Bundle
 

--- a/src/main/scala/devices/spi/SPIFIFO.scala
+++ b/src/main/scala/devices/spi/SPIFIFO.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.spi
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 class SPIFIFOControl(c: SPIParamsBase) extends SPIBundle(c) {
   val fmt = new SPIFormat(c) with HasSPILength

--- a/src/main/scala/devices/spi/SPIFlash.scala
+++ b/src/main/scala/devices/spi/SPIFlash.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.spi
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
 import freechips.rocketchip.diplomaticobjectmodel.model.{OMComponent, OMRegister}
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{LogicalModuleTree, LogicalTreeNode}

--- a/src/main/scala/devices/spi/SPIMedia.scala
+++ b/src/main/scala/devices/spi/SPIMedia.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.spi
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 class SPILinkIO(c: SPIParamsBase) extends SPIBundle(c) {
   val tx = Decoupled(Bits(width = c.frameBits))

--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.spi
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Field
 import freechips.rocketchip.subsystem.{BaseSubsystem}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/spi/SPIPhysical.scala
+++ b/src/main/scala/devices/spi/SPIPhysical.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.spi
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.util.ShiftRegInit
 
 class SPIMicroOp(c: SPIParamsBase) extends SPIBundle(c) {

--- a/src/main/scala/devices/spi/SPIPins.scala
+++ b/src/main/scala/devices/spi/SPIPins.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.spi
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import chisel3.{withClockAndReset}
 import freechips.rocketchip.util.{SynchronizerShiftReg}
 import sifive.blocks.devices.pinctrl.{PinCtrl, Pin}

--- a/src/main/scala/devices/spi/TLSPI.scala
+++ b/src/main/scala/devices/spi/TLSPI.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.spi
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._

--- a/src/main/scala/devices/spi/TLSPIFlash.scala
+++ b/src/main/scala/devices/spi/TLSPIFlash.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.spi
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._

--- a/src/main/scala/devices/stream/PseudoStream.scala
+++ b/src/main/scala/devices/stream/PseudoStream.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.stream
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/timer/Timer.scala
+++ b/src/main/scala/devices/timer/Timer.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.timer
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.subsystem.BaseSubsystem

--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.uart
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._

--- a/src/main/scala/devices/uart/UARTPins.scala
+++ b/src/main/scala/devices/uart/UARTPins.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.uart
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import chisel3.{withClockAndReset}
 import freechips.rocketchip.util.SyncResetSynchronizerShiftReg
 import sifive.blocks.devices.pinctrl.{Pin}

--- a/src/main/scala/devices/uart/UARTRx.scala
+++ b/src/main/scala/devices/uart/UARTRx.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.uart
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/uart/UARTTx.scala
+++ b/src/main/scala/devices/uart/UARTTx.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.uart
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import freechips.rocketchip.util._
 

--- a/src/main/scala/devices/wdt/TLWDT.scala
+++ b/src/main/scala/devices/wdt/TLWDT.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.devices.wdt
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import Chisel.ImplicitConversions._
 import chisel3.MultiIOModule
 

--- a/src/main/scala/util/DeglitchShiftRegister.scala
+++ b/src/main/scala/util/DeglitchShiftRegister.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.util
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 //Allows us to specify a different clock for a shift register
 // and to force input to be high for > 1 cycle.

--- a/src/main/scala/util/Devices.scala
+++ b/src/main/scala/util/Devices.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.util
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalTreeNode

--- a/src/main/scala/util/RegMapFIFO.scala
+++ b/src/main/scala/util/RegMapFIFO.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.util
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.regmapper._
 
 // MSB indicates full status

--- a/src/main/scala/util/SlaveRegIF.scala
+++ b/src/main/scala/util/SlaveRegIF.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.util
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import freechips.rocketchip.regmapper._
 
 class SlaveRegIF(private val w: Int) extends Bundle {

--- a/src/main/scala/util/Timer.scala
+++ b/src/main/scala/util/Timer.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package sifive.blocks.util
 
-import Chisel._
+import Chisel.{defaultCompileOptions => _, _}
+import freechips.rocketchip.util.CompileOptions.NotStrictInferReset
 import Chisel.ImplicitConversions._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.util.WideCounter


### PR DESCRIPTION
To support SubsystemResetSchemesKey = ResetAsynchronous and ResetAsynchronousFull, reset types throughout sifive-blocks are being changed from `Bool()` to `Reset()`. Changing all the modules to chisel3 is one option to support abstract reset, but it is far easier to make a 2-line change to the imports.

@jackkoenig described it this way: "Looks a little arcane, but basically we’re suppressing the default options that come from `import Chisel._` and providing our own called `NotStrictInferReset`"