### PR TITLE
Enforce a common makePort method for DeviceAttachParams

### DIFF
--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -92,7 +92,7 @@ abstract class GPIO(busWidthBytes: Int, c: GPIOParams)(implicit p: Parameters)
   // HW IO Function
   val iofEnReg  = Module(new AsyncResetRegVec(c.width, 0))
   val iofSelReg = Reg(init = UInt(0, c.width))
-  
+
   // Invert Output
   val xorReg    = Reg(init = UInt(0, c.width))
 
@@ -194,7 +194,7 @@ abstract class GPIO(busWidthBytes: Int, c: GPIOParams)(implicit p: Parameters)
       // Allow SW Override for things IOF doesn't control.
       iofPlusSwPinCtrl(pin) <> swPinCtrl(pin)
       iofPlusSwPinCtrl(pin) <> iofCtrl(pin)
-   
+
       // Final XOR & Pin Control
       pre_xor  := Mux(iofEnReg.io.q(pin), iofPlusSwPinCtrl(pin), swPinCtrl(pin))
     } else {
@@ -286,6 +286,12 @@ case class GPIOAttachParams(
     LogicalModuleTree.add(where.logicalTreeNode, gpio.logicalTreeNode)
 
     gpio
+  }
+
+  type T = GPIOPortIO
+  def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
+    val gpioNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()
+    InModuleBody { gpioNode.makeIO()(ValName(name)) }
   }
 }
 

--- a/src/main/scala/devices/gpio/GPIO.scala
+++ b/src/main/scala/devices/gpio/GPIO.scala
@@ -289,10 +289,13 @@ case class GPIOAttachParams(
     gpio
   }
 
+  val deviceType = classOf[TLGPIO]
+
   type T = GPIOPortIO
   def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
-    val gpioNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()
-    InModuleBody { gpioNode.makeIO()(ValName(name)) }
+    /* val gpioNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()
+    InModuleBody { gpioNode.makeIO()(ValName(name)) } */
+    GPIO.makePort(node.asInstanceOf[BundleBridgeSource[T]], name)
   }
 }
 

--- a/src/main/scala/devices/i2c/I2C.scala
+++ b/src/main/scala/devices/i2c/I2C.scala
@@ -631,6 +631,7 @@ case class I2CAttachParams(
     i2c
   }
 
+  val deviceType = classOf[TLI2C]
   type T = I2CPort
   def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
     val i2cNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()

--- a/src/main/scala/devices/i2c/I2C.scala
+++ b/src/main/scala/devices/i2c/I2C.scala
@@ -629,6 +629,12 @@ case class I2CAttachParams(
 
     i2c
   }
+
+  type T = I2CPort
+  def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
+    val i2cNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()
+    InModuleBody { i2cNode.makeIO()(ValName(name)) }
+  }
 }
 
 object I2C {

--- a/src/main/scala/devices/pwm/PWM.scala
+++ b/src/main/scala/devices/pwm/PWM.scala
@@ -171,6 +171,7 @@ case class PWMAttachParams(
     pwm
   }
 
+  val deviceType = classOf[TLPWM]
   type T = PWMPortIO
   def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
     val pwmNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()

--- a/src/main/scala/devices/pwm/PWM.scala
+++ b/src/main/scala/devices/pwm/PWM.scala
@@ -169,6 +169,12 @@ case class PWMAttachParams(
 
     pwm
   }
+
+  type T = PWMPortIO
+  def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
+    val pwmNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()
+    InModuleBody { pwmNode.makeIO()(ValName(name)) }
+  }
 }
 
 object PWM {

--- a/src/main/scala/devices/spi/SPI.scala
+++ b/src/main/scala/devices/spi/SPI.scala
@@ -70,6 +70,13 @@ case class SPIAttachParams(
 
     spi
   }
+
+  type T = SPIPortIO
+  def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
+    //val spiNode = node.makeSink()
+    val spiNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()
+    InModuleBody { spiNode.makeIO()(ValName(name)) }
+  }
 }
 
 case class SPIFlashLocated(loc: HierarchicalLocation) extends Field[Seq[SPIFlashAttachParams]](Nil)
@@ -141,6 +148,12 @@ case class SPIFlashAttachParams(
     LogicalModuleTree.add(where.logicalTreeNode, qspi.logicalTreeNode)
 
     qspi
+  }
+
+  type T = SPIPortIO
+  def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
+    val spiNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()
+    InModuleBody { spiNode.makeIO()(ValName(name)) }
   }
 }
 

--- a/src/main/scala/devices/spi/SPI.scala
+++ b/src/main/scala/devices/spi/SPI.scala
@@ -72,6 +72,7 @@ case class SPIAttachParams(
     spi
   }
 
+  val deviceType = classOf[TLSPI]
   type T = SPIPortIO
   def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
     //val spiNode = node.makeSink()
@@ -151,6 +152,7 @@ case class SPIFlashAttachParams(
     qspi
   }
 
+  val deviceType = classOf[TLSPIFlash]
   type T = SPIPortIO
   def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
     val spiNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()

--- a/src/main/scala/devices/stream/PseudoStream.scala
+++ b/src/main/scala/devices/stream/PseudoStream.scala
@@ -134,6 +134,12 @@ case class PseudoStreamAttachParams(
 
     stream
   }
+
+  type T = PseudoStreamPortIO
+  def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
+    val streamNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()
+    InModuleBody { streamNode.makeIO()(ValName(name)) }
+  }
 }
 
 object PseudoStream {

--- a/src/main/scala/devices/stream/PseudoStream.scala
+++ b/src/main/scala/devices/stream/PseudoStream.scala
@@ -136,6 +136,7 @@ case class PseudoStreamAttachParams(
     stream
   }
 
+  val deviceType = classOf[TLPseudoStream]
   type T = PseudoStreamPortIO
   def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
     val streamNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()

--- a/src/main/scala/devices/timer/Timer.scala
+++ b/src/main/scala/devices/timer/Timer.scala
@@ -129,6 +129,7 @@ case class TimerAttachParams(
     timer
   }
 
+  val deviceType = classOf[Timer]
   type T = Bundle
   def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
     val timerNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()

--- a/src/main/scala/devices/timer/Timer.scala
+++ b/src/main/scala/devices/timer/Timer.scala
@@ -46,7 +46,7 @@ class Timer(w: Int, c: TimerParams)(implicit p: Parameters)
     interrupts := timer.io.ip
     val mapping = (GenericTimer.timerRegMap(timer, 0, c.regBytes))
     regmap(mapping:_*)
-    val omRegMap = OMRegister.convert(mapping:_*)  
+    val omRegMap = OMRegister.convert(mapping:_*)
   }
   val logicalTreeNode = new LogicalTreeNode(() => Some(device)) {
     def getOMComponents(resourceBindings: ResourceBindings, children: Seq[OMComponent] = Nil): Seq[OMComponent] = {
@@ -126,6 +126,12 @@ case class TimerAttachParams(
     LogicalModuleTree.add(where.logicalTreeNode, timer.logicalTreeNode)
 
     timer
+  }
+
+  type T = Bundle
+  def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
+    val timerNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()
+    InModuleBody { timerNode.makeIO()(ValName(name)) }
   }
 }
 

--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -90,7 +90,7 @@ class UART(busWidthBytes: Int, val c: UARTParams, divisorInit: Int = 0)
   val enwire4 = Reg(init = Bool(false))
   val invpol = Reg(init = Bool(false))
   val enparity = Reg(init = Bool(false))
-  val parity = Reg(init = Bool(false)) // Odd parity - 1 , Even parity - 0 
+  val parity = Reg(init = Bool(false)) // Odd parity - 1 , Even parity - 0
   val errorparity = Reg(init = Bool(false))
   val errie = Reg(init = Bool(false))
   val txwm = Reg(init = UInt(0, txCountBits))
@@ -102,7 +102,7 @@ class UART(busWidthBytes: Int, val c: UARTParams, divisorInit: Int = 0)
     txm.io.en := txen && (!port.cts_n.get || !enwire4)
     txm.io.cts_n.get := port.cts_n.get
   }
-  else 
+  else
     txm.io.en := txen
   txm.io.in <> txq.io.deq
   txm.io.div := div
@@ -274,6 +274,12 @@ case class UARTAttachParams(
     LogicalModuleTree.add(where.logicalTreeNode, uart.logicalTreeNode)
 
     uart
+  }
+
+  type T = UARTPortIO
+  def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
+    val uartNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()
+    InModuleBody { uartNode.makeIO()(ValName(name)) }
   }
 }
 

--- a/src/main/scala/devices/uart/UART.scala
+++ b/src/main/scala/devices/uart/UART.scala
@@ -279,9 +279,10 @@ case class UARTAttachParams(
     uart
   }
 
-  type T = UARTPortIO
-  def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
-    val uartNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()
+  val deviceType = classOf[TLUART]
+  //type T = UARTPortIO
+  def makePort[UARTPortIO](node: BundleBridgeSource[UARTPortIO], name: String)(implicit p: Parameters): ModuleValue[UARTPortIO] = {
+    val uartNode = node.makeSink()
     InModuleBody { uartNode.makeIO()(ValName(name)) }
   }
 }

--- a/src/main/scala/devices/wdt/TLWDT.scala
+++ b/src/main/scala/devices/wdt/TLWDT.scala
@@ -52,7 +52,7 @@ abstract class WDT(busWidthBytes: Int, val params: WDTParams)(implicit p: Parame
     //regmap((GenericTimer.timerRegMap(wdt, 0, params.regBytes)):_*)
     val mapping = (GenericTimer.timerRegMap(wdt, 0, params.regBytes))
     regmap(mapping:_*)
-    val omRegMap = OMRegister.convert(mapping:_*)  
+    val omRegMap = OMRegister.convert(mapping:_*)
   }
 
   val logicalTreeNode = new LogicalTreeNode(() => Some(device)) {
@@ -121,6 +121,12 @@ case class WDTAttachParams(
     LogicalModuleTree.add(where.logicalTreeNode, wdt.logicalTreeNode)
 
     wdt
+  }
+
+  type T = WDTPortIO
+  def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
+    val wdtNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()
+    InModuleBody { wdtNode.makeIO()(ValName(name)) }
   }
 }
 

--- a/src/main/scala/devices/wdt/TLWDT.scala
+++ b/src/main/scala/devices/wdt/TLWDT.scala
@@ -124,6 +124,7 @@ case class WDTAttachParams(
     wdt
   }
 
+  val deviceType = classOf[TLWDT]
   type T = WDTPortIO
   def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T] = {
     val wdtNode = node.asInstanceOf[BundleBridgeSource[T]].makeSink()

--- a/src/main/scala/util/Devices.scala
+++ b/src/main/scala/util/Devices.scala
@@ -33,6 +33,9 @@ trait DeviceAttachParams {
   val controlXType: ClockCrossingType
 
   def attachTo(where: Attachable)(implicit p: Parameters): LazyModule
+  type T <: Bundle
+  def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T]
+
 }
 
 case class DevicesSubsystemParams(

--- a/src/main/scala/util/Devices.scala
+++ b/src/main/scala/util/Devices.scala
@@ -29,13 +29,14 @@ trait DeviceParams
 
 trait DeviceAttachParams {
   val device: DeviceParams
+  val deviceType: Class[_]
   val controlWhere: TLBusWrapperLocation
   val blockerAddr: Option[BigInt]
   val controlXType: ClockCrossingType
 
   def attachTo(where: Attachable)(implicit p: Parameters): LazyModule
   type T <: Bundle
-  def makePort(node: BundleBridgeSource[_], name: String)(implicit p: Parameters): ModuleValue[T]
+  def makePort[T<:Bundle](node: BundleBridgeSource[T], name: String)(implicit p: Parameters): ModuleValue[T]
 
 }
 


### PR DESCRIPTION
Updated the devices API.
* Added a `makePort` method to the `DeviceAttachParams` trait.
* Updated the attach params definition for all devices that extend `DeviceAttachParams` to implement a `makePort` definition.