### PR TITLE
Expose TL node(s) in periphery

### DIFF
--- a/src/main/scala/devices/spi/SPIPeriphery.scala
+++ b/src/main/scala/devices/spi/SPIPeriphery.scala
@@ -10,9 +10,10 @@ import freechips.rocketchip.diplomacy._
 case object PeripherySPIKey extends Field[Seq[SPIParams]](Nil)
 
 trait HasPeripherySPI { this: BaseSubsystem =>
-  val spiNodes = p(PeripherySPIKey).map { ps =>
-    SPIAttachParams(ps).attachTo(this).ioNode.makeSink() 
+  val tlSpiNodes = p(PeripherySPIKey).map { ps =>
+    SPIAttachParams(ps).attachTo(this)
   }
+  val spiNodes = tlSpiNodes.map { n => n.ioNode.makeSink() }
 }
 
 trait HasPeripherySPIBundle {
@@ -27,9 +28,10 @@ trait HasPeripherySPIModuleImp extends LazyModuleImp with HasPeripherySPIBundle 
 case object PeripherySPIFlashKey extends Field[Seq[SPIFlashParams]](Nil)
 
 trait HasPeripherySPIFlash { this: BaseSubsystem =>
-  val qspiNodes = p(PeripherySPIFlashKey).map { ps =>
-    SPIFlashAttachParams(ps, fBufferDepth = 8).attachTo(this).ioNode.makeSink()
+  val tlQSpiNodes = p(PeripherySPIFlashKey).map { ps =>
+    SPIFlashAttachParams(ps, fBufferDepth = 8).attachTo(this)
   }
+  val qspiNodes = tlQSpiNodes.map { n => n.ioNode.makeSink() }
 }
 
 trait HasPeripherySPIFlashBundle {


### PR DESCRIPTION
This exposes the TL SPI nodes so that the `MMCDevice`/`FlashDevice` can be attached to them in the system that has the corresponding mixin (i.e. `HasPeripherySPI` / `HasPeripherySPIFlash`).

**Background Info:**

Currently `sifive-blocks` has both an `MMCDevice` and `FlashDevice` that can be bound to a TL SPI node to append to the DTS/DTB (https://github.com/sifive/sifive-blocks/blob/5945cde07f187b022599263e4f9ee150503166d7/src/main/scala/devices/spi/TLSPI.scala#L151-L175). So far as I know, the main way to add one of these devices is to do something like the following:

```
ResourceBinding {
  Resource(new MMCDevice(tlSpiNode.device, 1), "reg").bind(ResourceAddress(0))
}
```

where the `tlSpiNode` is the TL SPI node that you want to add the DTS snippet to. This method of adding to the DTS was done in the Freedom platform (https://github.com/sifive/freedom/blob/943ab4ac2cefbbabdeda9447ec0f6231f6235f1e/src/main/scala/unleashed/DevKitFPGADesign.scala#L88-L91).

However, in newer versions of `sifive-blocks` this functionality was removed since the TL node is never exposed (only the IO's are exposed). This PR re-exposes the TL node like before while keeping the default functionality.