### PR TITLE
I2C: Add reg-shift = <2>; to device tree

### DIFF
--- a/src/main/scala/devices/i2c/I2C.scala
+++ b/src/main/scala/devices/i2c/I2C.scala
@@ -81,6 +81,8 @@ abstract class I2C(busWidthBytes: Int, params: I2CParams)(implicit p: Parameters
       new I2CPort)
     with HasInterruptSources {
 
+  override def extraResources(resources: ResourceBindings) = Map(
+	  "reg-shift" -> Seq(ResourceInt(2)))
   def nInterrupts = 1
 
   lazy val module = new LazyModuleImp(this) {


### PR DESCRIPTION
Commit 72e4b60 made the I2C control registers 32-bit aligned to match the rest of the system. However, the OpenCores I2C driver (https://github.com/torvalds/linux/blob/master/drivers/i2c/busses/i2c-ocores.c) expects registers to be 8-bit aligned.

In cases where a user relies on a generated device tree instead of a custom one (e.g. in HiFive bootloaders https://github.com/sifive/freedom-u540-c000-bootloader/blob/master/fsbl/ux00_fsbl.dts#L300), the I2C block will not be functional because control registers will be improperly written. Setting `reg-shift = <2>;` this way allows the OpenCores driver to work properly by default.

This may break some custom drivers out there, but in the case of the Zephyr project driver (https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/i2c/i2c_sifive.c), this property is unused because it already expects 32-bit aligned registers.

Potentially addresses #154. Special thanks to @a0u for debugging.